### PR TITLE
Provide `DefaultUserProvider`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [unreleased]
 
+### Added
+
+- New `UserProviderInterface` implementation: `DefaultUserProvider` for default action to acquire user information from URL
+- New Option: `OAuth2ProviderKeyConstant::USER_INFO_URL` option for provider
+
 ## [0.1.2] - 2018-04-30
 ### Added
 
@@ -41,7 +46,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 
 
-[unreleased]: https://github.com/ridi/php-oauth2/compare/v0.1.1...HEAD
+[unreleased]: https://github.com/ridi/php-oauth2/compare/v0.1.2...HEAD
 [0.1.2]: https://github.com/ridi/php-oauth2/compare/v0.1.1...v0.1.2
 [0.1.1]: https://github.com/ridi/php-oauth2/compare/v0.1.0...v0.1.1
 [0.1.0]: https://github.com/ridi/php-oauth2/compare/v0.0.2...v0.1.0

--- a/README.md
+++ b/README.md
@@ -9,7 +9,8 @@
 ## Requirements
 
 - `PHP 7.1` or higher
-- `Silex v1.2.x or v1.3.x`
+- `silex/silex v1.2.x or v1.3.x` (optional)
+- `guzzlehttp/guzzle` (optional)
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@
 
 ```bash
 composer require ridibooks/oauth2
+// If needed
+composer require silex/silex:1.3 guzzlehttp/guzzle
 ```
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -6,18 +6,52 @@
 - OAuth2 클라이언트와 리소스 서버를 구축하기 위한 PHP 라이브러리입니다.
 - Ridi 스타일 가이드([내부 서비스간의 SSO](https://github.com/ridi/style-guide/blob/master/API.md#%EB%82%B4%EB%B6%80-%EC%84%9C%EB%B9%84%EC%8A%A4%EA%B0%84%EC%9D%98-sso))에 따라 작성 되었습니다.
 
-## 필요 조건
+## Requirements
 
 - `PHP 7.1` or higher
 - `Silex v1.2.x or v1.3.x`
 
-## 설치
+## Installation
 
 ```bash
 composer require ridibooks/oauth2
 ```
 
 ## Usage
+
+### Options
+
+- **`OAuth2ProviderKeyConstant::CLIENT_ID`**: (default = `null`)
+- **`OAuth2ProviderKeyConstant::CLIENT_SECRET`**: (default = `null`)
+- **`OAuth2ProviderKeyConstant::CLIENT_DEFAULT_SCOPE`**: (default = `[]`) 미들웨어에서 체크할 scope 기본값
+- **`OAuth2ProviderKeyConstant::CLIENT_DEFAULT_REDIRECT_URI`**: (default = `null`)
+- **`OAuth2ProviderKeyConstant::AUTHORIZE_URL`**: (default = `https://account.ridibooks.com/oauth2/authorize/`)
+- **`OAuth2ProviderKeyConstant::TOKEN_URL`**: (default = `https://account.ridibooks.com/oauth2/token/`)
+- **`OAuth2ProviderKeyConstant::USER_INFO_URL`**: (default = `https://account.ridibooks.com/accounts/me/`)
+- **`OAuth2ProviderKeyConstant::JWT_ALGORITHM`**: (default = `HS256`)
+- **`OAuth2ProviderKeyConstant::JWT_SECRET`**: (default = `secret`)
+- **`OAuth2ProviderKeyConstant::JWT_EXPIRE_TERM`**: (default = `60 * 5` seconds)
+- **`OAuth2ProviderKeyConstant::DEFAULT_EXCEPTION_HANDLER`**: (default = `null`) 미들웨어에서 사용할 기본 `OAuth2ExceptionHandlerInterface` 구현체
+- **`OAuth2ProviderKeyConstant::DEFAULT_USER_PROVIDER`**: (default = `DefaultUserProvider`) 미들웨어에서 사용할 기본 `UserProviderInterface` 구현체
+
+### Services
+
+- **`OAuth2ProviderKeyConstant::GRANTER`**
+    - `authorize(string $state, string $redirect_uri = null, array $scope = null): string`: `/authorize`를 위한 URL을 반환
+- **`OAuth2ProviderKeyConstant::AUTHORIZER`**
+	- `autorize(Request $request): JwtToken`: `access_token` 유효성 검사 후 `JwtToken` 객체를 반환
+- **`OAuth2ProviderKeyConstant::MIDDLEWARE`**
+	- `authorize(OAuth2ExceptionHandlerInterface $exception_handler = null, UserProviderInterface $user_provider = null, array $required_scopes = [])`: 미들웨어를 반환
+
+### Built-in `OAuth2ExceptionHandlerInterface` Implementations
+
+- **`IgnoreExceptionHandler`**: 인증 관련 오류를 무시
+- **`LoginRequiredExceptionHandler`**: 인증 오류시 `401 UNAUTHORIZED`, `403 FORBIDDEN` 에러 발생 
+- **`LoginForcedExceptionHandler`**: 인증 오류시 `OAuth2ProviderKeyConstant::AUTHORIZE_URL`로 redirect
+
+### Built-in `UserProviderInterface` Implementations
+
+- **`DefaultUserProvider`**: 정해진 URL을 통해 사용자 정보를 조회
 
 ### `ridi.oauth2.middleware` 서비스: `Silex`와 함께 사용하기
 
@@ -49,34 +83,6 @@ public function authRequiredApi(Application $app)
 }
 ```
 
-#### 사용 가능한 옵션
-
-- **`OAuth2ProviderKeyConstant::CLIENT_ID`**: (default = `null`)
-- **`OAuth2ProviderKeyConstant::CLIENT_SECRET`**: (default = `null`)
-- **`OAuth2ProviderKeyConstant::CLIENT_DEFAULT_SCOPE`**: (default = `[]`) 미들웨어에서 체크할 scope 기본값
-- **`OAuth2ProviderKeyConstant::CLIENT_DEFAULT_REDIRECT_URI`**: (default = `null`)
-- **`OAuth2ProviderKeyConstant::AUTHORIZE_URL`**: (default = `https://account.ridibooks.com/oauth2/authorize`)
-- **`OAuth2ProviderKeyConstant::TOKEN_URL`**: (default = `https://account.ridibooks.com/oauth2/token`)
-- **`OAuth2ProviderKeyConstant::JWT_ALGORITHM`**: (default = `HS256`)
-- **`OAuth2ProviderKeyConstant::JWT_SECRET`**: (default = `secret`)
-- **`OAuth2ProviderKeyConstant::JWT_EXPIRE_TERM`**: (default = `60 * 5` seconds)
-- **`OAuth2ProviderKeyConstant::DEFAULT_EXCEPTION_HANDLER`**: (default = `null`) 미들웨어에서 사용할 기본 `OAuth2ExceptionHandlerInterface` 구현체
-- **`OAuth2ProviderKeyConstant::DEFAULT_USER_PROVIDER`**: (default = `null`) 미들웨어에서 사용할 기본 `UserProviderInterface` 구현체
-
-#### 서비스
-
-- **`OAuth2ProviderKeyConstant::GRANTER`**
-    - `authorize(string $state, string $redirect_uri = null, array $scope = null): string`: `/authorize`를 위한 URL을 반환
-- **`OAuth2ProviderKeyConstant::AUTHORIZER`**
-	- `autorize(Request $request): JwtToken`: `access_token` 유효성 검사 후 `JwtToken` 객체를 반환
-- **`OAuth2ProviderKeyConstant::MIDDLEWARE`**
-	- `authorize(OAuth2ExceptionHandlerInterface $exception_handler = null, UserProviderInterface $user_provider = null, array $required_scopes = [])`: 미들웨어를 반환
-
-#### `OAuth2ExceptionHandlerInterface` 구현체
-
-- **`IgnoreExceptionHandler`**: 인증 관련 오류를 무시
-- **`LoginRequiredExceptionHandler`**: 인증 오류시 `401 UNAUTHORIZED`, `403 FORBIDDEN` 에러 발생 
-- **`LoginForcedExceptionHandler`**: 인증 오류시 `OAuth2ProviderKeyConstant::AUTHORIZE_URL`로 redirect
 
 ### `ridi.oauth2.authorizer` 서비스
 

--- a/README.md
+++ b/README.md
@@ -55,32 +55,6 @@ $authorization_url = $granter->authorize();
 
 `OAuth2ServiceProvider`를 Silex 애플리케이션에 등록(`register`)해 사용한다.
 
-### Options
-
-- **`OAuth2ProviderKeyConstant::CLIENT_ID`**: (default = `null`)
-- **`OAuth2ProviderKeyConstant::CLIENT_SECRET`**: (default = `null`)
-- **`OAuth2ProviderKeyConstant::CLIENT_DEFAULT_SCOPE`**: (default = `[]`) 미들웨어에서 체크할 scope 기본값
-- **`OAuth2ProviderKeyConstant::CLIENT_DEFAULT_REDIRECT_URI`**: (default = `null`)
-- **`OAuth2ProviderKeyConstant::AUTHORIZE_URL`**: (default = `https://account.ridibooks.com/oauth2/authorize/`)
-- **`OAuth2ProviderKeyConstant::TOKEN_URL`**: (default = `https://account.ridibooks.com/oauth2/token/`)
-- **`OAuth2ProviderKeyConstant::USER_INFO_URL`**: (default = `https://account.ridibooks.com/accounts/me/`)
-- **`OAuth2ProviderKeyConstant::JWT_ALGORITHM`**: (default = `HS256`)
-- **`OAuth2ProviderKeyConstant::JWT_SECRET`**: (default = `secret`)
-- **`OAuth2ProviderKeyConstant::JWT_EXPIRE_TERM`**: (default = `60 * 5` seconds)
-- **`OAuth2ProviderKeyConstant::DEFAULT_EXCEPTION_HANDLER`**: (default = `null`) 미들웨어에서 사용할 기본 `OAuth2ExceptionHandlerInterface` 구현체
-- **`OAuth2ProviderKeyConstant::DEFAULT_USER_PROVIDER`**: (default = `DefaultUserProvider`) 미들웨어에서 사용할 기본 `UserProviderInterface` 구현체
-
-#### Built-in `OAuth2ExceptionHandlerInterface` Implementations
-
-- **`IgnoreExceptionHandler`**: 인증 관련 오류를 무시
-- **`LoginRequiredExceptionHandler`**: 인증 오류시 `401 UNAUTHORIZED`, `403 FORBIDDEN` 에러 발생 
-- **`LoginForcedExceptionHandler`**: 인증 오류시 `OAuth2ProviderKeyConstant::AUTHORIZE_URL`로 redirect
-
-#### Built-in `UserProviderInterface` Implementations
-
-- **`DefaultUserProvider`**: 정해진 URL을 통해 사용자 정보를 조회
-
-
 ### Services
 
 - **`OAuth2ProviderKeyConstant::GRANTER`**

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,8 @@
   "license": "MIT",
   "require": {
     "firebase/php-jwt": "^4.0 || ^5.0",
-    "silex/silex": "^1.3"
+    "silex/silex": "^1.3",
+    "guzzlehttp/guzzle": "^6.3"
   },
   "require-dev": {
     "phpunit/phpunit": "^6"

--- a/composer.json
+++ b/composer.json
@@ -4,12 +4,16 @@
   "type": "library",
   "license": "MIT",
   "require": {
-    "firebase/php-jwt": "^4.0 || ^5.0",
-    "silex/silex": "^1.3",
-    "guzzlehttp/guzzle": "^6.3"
+    "firebase/php-jwt": "^4.0 || ^5.0"
   },
   "require-dev": {
+    "silex/silex": "^1.3",
+    "guzzlehttp/guzzle": "^6.3",
     "phpunit/phpunit": "^6"
+  },
+  "suggest": {
+    "silex/silex": "Required when using `OAuth2ServiceProvider`(compatible with `1.x.x` version)",
+    "guzzlehttp/guzzle": "Required when using `OAuth2ServiceProvider` and `DefaultUserProvider`"
   },
   "autoload": {
     "psr-4": {

--- a/lib/Silex/Constant/OAuth2ProviderKeyConstant.php
+++ b/lib/Silex/Constant/OAuth2ProviderKeyConstant.php
@@ -12,6 +12,7 @@ class OAuth2ProviderKeyConstant
 
     const AUTHORIZE_URL = 'ridi.oauth2.authorize_url';
     const TOKEN_URL = 'ridi.oauth2.token_url';
+    const USER_INFO_URL = 'ridi.oauth2.user_info_url';
 
     const JWT_ALGORITHM = 'ridi.oauth2.jwt_algorithm';
     const JWT_SECRET = 'ridi.oauth2.jwt_secret';

--- a/lib/Silex/Provider/DefaultUserProvider.php
+++ b/lib/Silex/Provider/DefaultUserProvider.php
@@ -38,7 +38,10 @@ class DefaultUserProvider implements UserProviderInterface
 
         $client = new Client($this->http_options);
         try {
-            $response = $client->get($this->user_info_url, ['cookies' => $cookie_jar]);
+            $response = $client->get($this->user_info_url, [
+                'cookies' => $cookie_jar,
+                'headers' => ['Accept' => 'application/json'],
+            ]);
             $content = $response->getBody()->getContents();
         } catch (BadResponseException $e) {
             $status = $e->getResponse()->getStatusCode();

--- a/lib/Silex/Provider/DefaultUserProvider.php
+++ b/lib/Silex/Provider/DefaultUserProvider.php
@@ -1,6 +1,5 @@
 <?php declare(strict_types=1);
 
-
 namespace Ridibooks\OAuth2\Silex\Provider;
 
 use GuzzleHttp\Client;

--- a/lib/Silex/Provider/DefaultUserProvider.php
+++ b/lib/Silex/Provider/DefaultUserProvider.php
@@ -1,0 +1,63 @@
+<?php declare(strict_types=1);
+
+
+namespace Ridibooks\OAuth2\Silex\Provider;
+
+use GuzzleHttp\Client;
+use GuzzleHttp\Cookie\CookieJar;
+use GuzzleHttp\Exception\BadResponseException;
+use Ridibooks\OAuth2\Authorization\Exception\AuthorizationException;
+use Ridibooks\OAuth2\Authorization\Exception\TokenNotFoundException;
+use Ridibooks\OAuth2\Authorization\Exception\UserNotFoundException;
+use Ridibooks\OAuth2\Authorization\Token\JwtToken;
+use Ridibooks\OAuth2\Constant\AccessTokenConstant;
+use Silex\Application;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class DefaultUserProvider implements UserProviderInterface
+{
+    const TOKEN_COOKIE_DOMAIN = '.ridibooks.com';
+    private $user_info_url;
+    private $http_options;
+
+    public function __construct(string $user_info_url, array $http_options = [])
+    {
+        $this->user_info_url = $user_info_url;
+        $this->http_options = $http_options;
+    }
+
+    public function getUser(JwtToken $token, Request $request, Application $app)
+    {
+        $access_token = $request->cookies->get(AccessTokenConstant::ACCESS_TOKEN_COOKIE_KEY);
+        if ($access_token === null) {
+            throw new TokenNotFoundException();
+        }
+
+        $cookie_jar = CookieJar::fromArray([AccessTokenConstant::ACCESS_TOKEN_COOKIE_KEY => $access_token],
+            self::TOKEN_COOKIE_DOMAIN);
+
+        $client = new Client($this->http_options);
+        try {
+            $response = $client->get($this->user_info_url, ['cookies' => $cookie_jar]);
+            $content = $response->getBody()->getContents();
+        } catch (BadResponseException $e) {
+            $status = $e->getResponse()->getStatusCode();
+            if ($status === Response::HTTP_UNAUTHORIZED) {
+                throw new AuthorizationException('Unauthorized access_token');
+            }
+            if ($status === Response::HTTP_NOT_FOUND) {
+                throw new UserNotFoundException();
+            }
+            throw new AuthorizationException($e->getMessage());
+        } catch (\Exception $e) {
+            throw new AuthorizationException($e->getMessage());
+        }
+
+        $json = json_decode($content);
+        if ($json === null || !isset($json->result)) {
+            throw new AuthorizationException('Invalid JSON user info');
+        }
+        return $json->result;
+    }
+}

--- a/lib/Silex/Provider/OAuth2MiddlewareFactory.php
+++ b/lib/Silex/Provider/OAuth2MiddlewareFactory.php
@@ -37,7 +37,7 @@ class OAuth2MiddlewareFactory
                 $token = $this->authorizer->authorize($request, $required_scopes);
 
                 if (isset($user_provider)) {
-                    $user = $user_provider->getUser($token);
+                    $user = $user_provider->getUser($token, $request, $app);
                     $app[OAuth2ProviderKeyConstant::USER] = $user;
                 }
             } catch (AuthorizationException $e) {

--- a/lib/Silex/Provider/OAuth2ServiceProvider.php
+++ b/lib/Silex/Provider/OAuth2ServiceProvider.php
@@ -11,6 +11,58 @@ use Ridibooks\OAuth2\Silex\Constant\OAuth2ProviderKeyConstant;
 use Silex\Application;
 use Silex\ServiceProviderInterface;
 
+/**
+ * Class OAuth2ServiceProvider
+ *
+ * OAuth2 Service Provider for Silex
+ * @see https://silex.symfony.com/doc/1.3/providers.html
+ *
+ * @package Ridibooks\OAuth2\Silex\Provider
+ *
+ * **Example usage:**
+ * ```php
+ *      $app->register(new OAuth2ServiceProvider(), [
+ *          OAuth2ProviderKeyConstant::CLIENT_ID => 'example-client-id',
+ *          OAuth2ProviderKeyConstant::CLIENT_SECRET => 'example-client-secret',
+ *          OAuth2ProviderKeyConstant::JWT_ALGORITHM => 'HS256',
+ *          OAuth2ProviderKeyConstant::JWT_SECRET => 'example-secret'
+ *      ]);
+ *      ...
+ *      $app->get('/auth-required', [$this, 'authRequiredApi'])
+ *          ->before($app[OAuth2ProviderKeyConstant::MIDDLEWARE]->authorize(new LoginRequiredExceptionHandler(), new UserProvider());
+ * ```
+ *
+ * **`OAuth2ServiceProvider` Options: @see OAuth2ProviderKeyConstant**
+ *
+ * - OAuth2ProviderKeyConstant::CLIENT_ID: (default = null)
+ * - OAuth2ProviderKeyConstant::CLIENT_SECRET: (default = null)
+ * - OAuth2ProviderKeyConstant::CLIENT_DEFAULT_SCOPE: (default = []) Default required scopes checked at middleware
+ * - OAuth2ProviderKeyConstant::CLIENT_DEFAULT_REDIRECT_URI: (default = null)
+ * - OAuth2ProviderKeyConstant::AUTHORIZE_URL: (default = https://account.ridibooks.com/oauth2/authorize/)
+ * - OAuth2ProviderKeyConstant::TOKEN_URL: (default = https://account.ridibooks.com/oauth2/token/)
+ * - OAuth2ProviderKeyConstant::USER_INFO_URL: (default = https://account.ridibooks.com/accounts/me/)
+ * - OAuth2ProviderKeyConstant::JWT_ALGORITHM: (default = HS256)
+ * - OAuth2ProviderKeyConstant::JWT_SECRET: (default = secret)
+ * - OAuth2ProviderKeyConstant::JWT_EXPIRE_TERM: (default = 60 * 5 seconds)
+ * - OAuth2ProviderKeyConstant::DEFAULT_EXCEPTION_HANDLER: (default = null) Default `OAuth2ExceptionHandlerInterface` implementation used by middleware
+ * - OAuth2ProviderKeyConstant::DEFAULT_USER_PROVIDER: (default = DefaultUserProvider) Default `UserProviderInterface` implementation used by middleware
+ *
+ * **Built-in `OAuth2ExceptionHandlerInterface` Implementations:**
+ *
+ * - **`IgnoreExceptionHandler`**: Ignore all `AuthorizationException`
+ * - **`LoginRequiredExceptionHandler`**: Handle `AuthorizationException` with `401 UNAUTHORIZED`, `403 FORBIDDEN` response
+ * - **`LoginForcedExceptionHandler`**: Redirect `OAuth2ProviderKeyConstant::AUTHORIZE_URL` when `AuthorizationException` is occurred
+ *
+ * **Built-in `UserProviderInterface` Implementations:**
+ *
+ * - **`DefaultUserProvider`**: Get user information through specified URL request with access_token
+ *
+ * **`OAuth2ServiceProvider` Services:**
+ *
+ * - OAuth2ProviderKeyConstant::GRANTER @see Granter
+ * - OAuth2ProviderKeyConstant::AUTHORIZER @see Authorizer
+ * - OAuth2ProviderKeyConstant::MIDDLEWARE @see OAuth2MiddlewareFactory
+ */
 class OAuth2ServiceProvider implements ServiceProviderInterface
 {
     private $app;

--- a/lib/Silex/Provider/OAuth2ServiceProvider.php
+++ b/lib/Silex/Provider/OAuth2ServiceProvider.php
@@ -25,15 +25,18 @@ class OAuth2ServiceProvider implements ServiceProviderInterface
         $app[OAuth2ProviderKeyConstant::CLIENT_DEFAULT_SCOPE] = [];
         $app[OAuth2ProviderKeyConstant::CLIENT_DEFAULT_REDIRECT_URI] = null;
 
-        $app[OAuth2ProviderKeyConstant::AUTHORIZE_URL] = 'https://account.ridibooks.com/oauth2/authorize';
-        $app[OAuth2ProviderKeyConstant::TOKEN_URL] = 'https://account.ridibooks.com/oauth2/token';
+        $app[OAuth2ProviderKeyConstant::AUTHORIZE_URL] = 'https://account.ridibooks.com/oauth2/authorize/';
+        $app[OAuth2ProviderKeyConstant::TOKEN_URL] = 'https://account.ridibooks.com/oauth2/token/';
+        $app[OAuth2ProviderKeyConstant::USER_INFO_URL] = 'https://account.ridibooks.com/accounts/me/';
 
         $app[OAuth2ProviderKeyConstant::JWT_ALGORITHM] = 'HS256';
         $app[OAuth2ProviderKeyConstant::JWT_SECRET] = 'secret';
         $app[OAuth2ProviderKeyConstant::JWT_EXPIRE_TERM] = 60 * 5;
 
         $app[OAuth2ProviderKeyConstant::DEFAULT_EXCEPTION_HANDLER] = null;
-        $app[OAuth2ProviderKeyConstant::DEFAULT_USER_PROVIDER] = null;
+        $app[OAuth2ProviderKeyConstant::DEFAULT_USER_PROVIDER] = function ($app) {
+            return new DefaultUserProvider($app[OAuth2ProviderKeyConstant::USER_INFO_URL]);
+        };
 
         $app[OAuth2ProviderKeyConstant::USER] = null;
         $app[OAuth2ProviderKeyConstant::STATE] = null;

--- a/lib/Silex/Provider/UserProviderInterface.php
+++ b/lib/Silex/Provider/UserProviderInterface.php
@@ -4,13 +4,17 @@ namespace Ridibooks\OAuth2\Silex\Provider;
 
 use Ridibooks\OAuth2\Authorization\Exception\AuthorizationException;
 use Ridibooks\OAuth2\Authorization\Token\JwtToken;
+use Silex\Application;
+use Symfony\Component\HttpFoundation\Request;
 
 interface UserProviderInterface
 {
     /**
      * @param JwtToken $token
+     * @param Request $request
+     * @param Application $app
      * @return mixed
      * @throws AuthorizationException
      */
-    public function getUser(JwtToken $token);
+    public function getUser(JwtToken $token, Request $request, Application $app);
 }

--- a/tests/Authorization/AuthorizerTest.php
+++ b/tests/Authorization/AuthorizerTest.php
@@ -1,8 +1,6 @@
 <?php declare(strict_types=1);
 
-
 namespace Ridibooks\Test\OAuth2\Authorization;
-
 
 use PHPUnit\Framework\TestCase;
 use Ridibooks\OAuth2\Authorization\Authorizer;

--- a/tests/Authorization/TokenValidatorTest.php
+++ b/tests/Authorization/TokenValidatorTest.php
@@ -9,7 +9,6 @@ use Ridibooks\OAuth2\Authorization\Exception\InvalidJwtException;
 use Ridibooks\OAuth2\Authorization\Exception\InvalidTokenException;
 use Ridibooks\OAuth2\Authorization\Exception\TokenNotFoundException;
 use Ridibooks\OAuth2\Authorization\Token\JwtToken;
-use Ridibooks\OAuth2\Authorization\Validator\JwtInfo;
 use Ridibooks\OAuth2\Authorization\Validator\JwtTokenValidator;
 use Ridibooks\Test\OAuth2\Common\TokenConstant;
 

--- a/tests/Common/TestUserProvider.php
+++ b/tests/Common/TestUserProvider.php
@@ -5,15 +5,19 @@ namespace Ridibooks\Test\OAuth2\Common;
 use Ridibooks\OAuth2\Authorization\Exception\UserNotFoundException;
 use Ridibooks\OAuth2\Authorization\Token\JwtToken;
 use Ridibooks\OAuth2\Silex\Provider\UserProviderInterface;
+use Silex\Application;
+use Symfony\Component\HttpFoundation\Request;
 
 class TestUserProvider implements UserProviderInterface
 {
     /**
      * @param JwtToken $token
+     * @param Request $request
+     * @param Application $app
      * @return mixed|\stdClass
      * @throws UserNotFoundException
      */
-    public function getUser(JwtToken $token)
+    public function getUser(JwtToken $token, Request $request, Application $app)
     {
         if ($token->getSubject() === 'unknown') {
             throw new UserNotFoundException();

--- a/tests/Silex/OAuth2MiddlewareFactoryTest.php
+++ b/tests/Silex/OAuth2MiddlewareFactoryTest.php
@@ -4,6 +4,7 @@ namespace Ridibooks\Test\OAuth2\Silex;
 
 use GuzzleHttp\Handler\MockHandler;
 use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Psr7\Response as GuzzleResponse;
 use PHPUnit\Framework\TestCase;
 use Ridibooks\OAuth2\Constant\AccessTokenConstant;
 use Ridibooks\OAuth2\Grant\Granter;
@@ -18,7 +19,6 @@ use Ridibooks\Test\OAuth2\Common\TokenConstant;
 use Silex\Application;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
-use GuzzleHttp\Psr7\Response as GuzzleResponse;
 
 class OAuth2MiddlewareFactoryTest extends TestCase
 {
@@ -201,7 +201,6 @@ class OAuth2MiddlewareFactoryTest extends TestCase
         $this->assertEquals(TokenConstant::USER_IDX, $app[OAuth2ProviderKeyConstant::USER]->idx);
         $this->assertEquals(TokenConstant::USERNAME, $app[OAuth2ProviderKeyConstant::USER]->id);
     }
-
 
     public function testDefaultUserProviderUserNotFound()
     {

--- a/tests/Silex/OAuth2MiddlewareFactoryTest.php
+++ b/tests/Silex/OAuth2MiddlewareFactoryTest.php
@@ -2,6 +2,8 @@
 
 namespace Ridibooks\Test\OAuth2\Silex;
 
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\HandlerStack;
 use PHPUnit\Framework\TestCase;
 use Ridibooks\OAuth2\Constant\AccessTokenConstant;
 use Ridibooks\OAuth2\Grant\Granter;
@@ -9,12 +11,14 @@ use Ridibooks\OAuth2\Silex\Constant\OAuth2ProviderKeyConstant;
 use Ridibooks\OAuth2\Silex\Handler\IgnoreExceptionHandler;
 use Ridibooks\OAuth2\Silex\Handler\LoginForcedExceptionHandler;
 use Ridibooks\OAuth2\Silex\Handler\LoginRequiredExceptionHandler;
+use Ridibooks\OAuth2\Silex\Provider\DefaultUserProvider;
 use Ridibooks\OAuth2\Silex\Provider\OAuth2ServiceProvider;
 use Ridibooks\Test\OAuth2\Common\TestUserProvider;
 use Ridibooks\Test\OAuth2\Common\TokenConstant;
 use Silex\Application;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
+use GuzzleHttp\Psr7\Response as GuzzleResponse;
 
 class OAuth2MiddlewareFactoryTest extends TestCase
 {
@@ -36,6 +40,14 @@ class OAuth2MiddlewareFactoryTest extends TestCase
         ], $options);
         $app->register(new OAuth2ServiceProvider(), $options);
         return $app;
+    }
+
+    private function getDefaultUserProvider(GuzzleResponse $expected_response)
+    {
+        $mock = new MockHandler([$expected_response]);
+        $handler = HandlerStack::create($mock);
+
+        return new DefaultUserProvider('/', ['handler' => $handler]);
     }
 
     public function testLoadUser()
@@ -157,6 +169,56 @@ class OAuth2MiddlewareFactoryTest extends TestCase
             ->before($app[OAuth2ProviderKeyConstant::MIDDLEWARE]->authorize());
 
         $access_token = TokenConstant::TOKEN_UNKNOWN_USER;
+        $req = Request::create('/', 'GET', [], [AccessTokenConstant::ACCESS_TOKEN_COOKIE_KEY => $access_token]);
+        $resp = $app->handle($req);
+
+        $this->assertEquals(Response::HTTP_UNAUTHORIZED, $resp->getStatusCode());
+    }
+
+    public function testDefaultUserProvider()
+    {
+        // Initialize DefaultUserProvider Mock
+        $body = [
+            "result" => [
+                "id" => TokenConstant::USERNAME,
+                "idx" => TokenConstant::USER_IDX,
+                "is_verified_adult" => true,
+            ],
+            "message" => "정상적으로 완료되었습니다."
+        ];
+        $response = new GuzzleResponse(200, [], json_encode($body));
+        $userProvider = $this->getDefaultUserProvider($response);
+
+        // Initialize App
+        $app = $this->registerProvider();
+        $app->get('/', function () {})
+            ->before($app[OAuth2ProviderKeyConstant::MIDDLEWARE]->authorize([], new IgnoreExceptionHandler(), $userProvider));
+
+        $access_token = TokenConstant::TOKEN_VALID;
+        $req = Request::create('/', 'GET', [], [AccessTokenConstant::ACCESS_TOKEN_COOKIE_KEY => $access_token]);
+        $app->handle($req);
+
+        $this->assertEquals(TokenConstant::USER_IDX, $app[OAuth2ProviderKeyConstant::USER]->idx);
+        $this->assertEquals(TokenConstant::USERNAME, $app[OAuth2ProviderKeyConstant::USER]->id);
+    }
+
+
+    public function testDefaultUserProviderUserNotFound()
+    {
+        // Initialize DefaultUserProvider Mock
+        $body = [
+            'code' => 'LOGIN_REQUIRED',
+            'message' => '로그인이 필요합니다.'
+        ];
+        $response = new GuzzleResponse(401, [], json_encode($body));
+        $userProvider = $this->getDefaultUserProvider($response);
+
+        // Initialize App
+        $app = $this->registerProvider();
+        $app->get('/', function () {})
+            ->before($app[OAuth2ProviderKeyConstant::MIDDLEWARE]->authorize([], new LoginRequiredExceptionHandler(), $userProvider));
+
+        $access_token = TokenConstant::TOKEN_VALID;
         $req = Request::create('/', 'GET', [], [AccessTokenConstant::ACCESS_TOKEN_COOKIE_KEY => $access_token]);
         $resp = $app->handle($req);
 


### PR DESCRIPTION
Account 서버에서 `/account/me/` API를 제공할 예정([관련 태스크](https://app.asana.com/0/0/630749151592740/f))이며, 내부 서비스들은 모두 이 API를 사용하게 됩니다.

개발자 편의를 위해 이 API를 사용해 사용자 정보를 가져오는 `DefaultUserProvider` 만들어 Silex Provider 설정의 기본값으로 제공하려고 합니다.

자유롭게 의견 주시면 감사하겠습니다~