### PR TITLE
Add refreshing access token feature

### DIFF
--- a/lib/Authorization/AuthorizeResult.php
+++ b/lib/Authorization/AuthorizeResult.php
@@ -1,0 +1,68 @@
+<?php declare(strict_types=1);
+
+namespace Ridibooks\OAuth2\Authorization;
+
+use Ridibooks\OAuth2\Authorization\Token\JwtToken;
+use Ridibooks\OAuth2\Grant\DataTransferObject\TokenData;
+
+class AuthorizeResult
+{
+    /** @var JwtToken */
+    private $jwt_token;
+
+    /** @var bool */
+    private $token_refreshed;
+
+    /** @var TokenData */
+    private $refreshed_token_data;
+
+    private function __construct(JwtToken $jwt_token, bool $token_refreshed, ?TokenData $refreshed_token_data)
+    {
+        $this->jwt_token = $jwt_token;
+        $this->token_refreshed = $token_refreshed;
+        $this->refreshed_token_data = $refreshed_token_data;
+    }
+
+    /**
+     * @param JwtToken $jwt_token
+     * @return AuthorizeResult
+     */
+    public static function createForAuthorizedToken(JwtToken $jwt_token)
+    {
+        return new AuthorizeResult($jwt_token, false, null);
+    }
+
+    /**
+     * @param JwtToken $jwt_token
+     * @param TokenData $refreshed_token_data
+     * @return AuthorizeResult
+     */
+    public static function createForRefreshedAndAuthorizedToken(JwtToken $jwt_token, TokenData $refreshed_token_data)
+    {
+        return new AuthorizeResult($jwt_token, true, $refreshed_token_data);
+    }
+
+    /**
+     * @return JwtToken
+     */
+    public function getJwtToken(): JwtToken
+    {
+        return $this->jwt_token;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isTokenRefreshed(): bool
+    {
+        return $this->token_refreshed;
+    }
+
+    /**
+     * @return TokenData
+     */
+    public function getRefreshedTokenData(): TokenData
+    {
+        return $this->refreshed_token_data;
+    }
+}

--- a/lib/Authorization/AuthorizeResult.php
+++ b/lib/Authorization/AuthorizeResult.php
@@ -10,16 +10,12 @@ class AuthorizeResult
     /** @var JwtToken */
     private $jwt_token;
 
-    /** @var bool */
-    private $token_refreshed;
-
     /** @var TokenData */
     private $refreshed_token_data;
 
-    private function __construct(JwtToken $jwt_token, bool $token_refreshed, ?TokenData $refreshed_token_data)
+    private function __construct(JwtToken $jwt_token, ?TokenData $refreshed_token_data)
     {
         $this->jwt_token = $jwt_token;
-        $this->token_refreshed = $token_refreshed;
         $this->refreshed_token_data = $refreshed_token_data;
     }
 
@@ -27,9 +23,9 @@ class AuthorizeResult
      * @param JwtToken $jwt_token
      * @return AuthorizeResult
      */
-    public static function createForAuthorizedToken(JwtToken $jwt_token)
+    public static function createFromAuthorizedToken(JwtToken $jwt_token)
     {
-        return new AuthorizeResult($jwt_token, false, null);
+        return new AuthorizeResult($jwt_token, null);
     }
 
     /**
@@ -37,9 +33,9 @@ class AuthorizeResult
      * @param TokenData $refreshed_token_data
      * @return AuthorizeResult
      */
-    public static function createForRefreshedAndAuthorizedToken(JwtToken $jwt_token, TokenData $refreshed_token_data)
+    public static function createFromRefreshedAndAuthorizedToken(JwtToken $jwt_token, TokenData $refreshed_token_data)
     {
-        return new AuthorizeResult($jwt_token, true, $refreshed_token_data);
+        return new AuthorizeResult($jwt_token, $refreshed_token_data);
     }
 
     /**
@@ -55,7 +51,7 @@ class AuthorizeResult
      */
     public function isTokenRefreshed(): bool
     {
-        return $this->token_refreshed;
+        return ($this->refreshed_token_data !== null);
     }
 
     /**

--- a/lib/Authorization/Authorizer.php
+++ b/lib/Authorization/Authorizer.php
@@ -5,49 +5,42 @@ namespace Ridibooks\OAuth2\Authorization;
 use Ridibooks\OAuth2\Authorization\Exception\ExpiredTokenException;
 use Ridibooks\OAuth2\Authorization\Exception\InsufficientScopeException;
 use Ridibooks\OAuth2\Authorization\Exception\TokenNotFoundException;
-use Ridibooks\OAuth2\Authorization\Token\JwtToken;
 use Ridibooks\OAuth2\Authorization\Validator\JwtTokenValidator;
-use Ridibooks\OAuth2\Constant\AccessTokenConstant;
-use Ridibooks\OAuth2\Grant\DataTransferObject\TokenData;
 use Ridibooks\OAuth2\Grant\Granter;
-use Ridibooks\OAuth2\Silex\Constant\OAuth2ProviderKeyConstant;
-use Silex\Application;
-use Symfony\Component\HttpFoundation\Cookie;
-use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\HttpFoundation\Response;
 
 class Authorizer
 {
     /** @var JwtTokenValidator */
     private $token_validator;
+    /** @var Granter */
+    private $granter;
     /** @var array */
     private $default_scopes;
 
-    public function __construct(JwtTokenValidator $token_validator, array $default_scopes = [])
+    public function __construct(JwtTokenValidator $token_validator, Granter $granter, array $default_scopes = [])
     {
         $this->token_validator = $token_validator;
+        $this->granter = $granter;
         $this->default_scopes = $default_scopes;
     }
 
-    public function authorize(Request $request, Application $app, array $required_scopes = [], bool $use_refreshing_access_token = false): JwtToken
-    {
-        $access_token = $request->cookies->get(AccessTokenConstant::ACCESS_TOKEN_COOKIE_KEY);
-
+    public function authorize(
+        ?string $access_token,
+        ?string $refresh_token,
+        array $required_scopes = [],
+        bool $use_refreshing_access_token = false
+    ): AuthorizeResult {
         // 1. Validate access_token
         try {
             $token = $this->token_validator->validateToken($access_token);
+            $authorize_result = AuthorizeResult::createForAuthorizedToken($token);
         } catch (TokenNotFoundException | ExpiredTokenException $e) {
-            $refresh_token = $request->cookies->get(AccessTokenConstant::REFRESH_TOKEN_COOKIE_KEY);
-
             // Refresh access token if requested
             if ($use_refreshing_access_token && !empty($refresh_token)) {
-                /** @var Granter $granter */
-                $granter = $app[OAuth2ProviderKeyConstant::GRANTER];
-
-                $token_data = $granter->refresh($refresh_token);
+                $token_data = $this->granter->refresh($refresh_token);
                 $token = $this->token_validator->validateToken($token_data->getAccessToken()->getToken());
 
-                $app->after($this->setTokenCookiesMiddleware($token_data));
+                $authorize_result = AuthorizeResult::createForRefreshedAndAuthorizedToken($token, $token_data);
             } else {
                 throw $e;
             }
@@ -57,43 +50,10 @@ class Authorizer
         if (empty($required_scopes)) {
             $required_scopes = $this->default_scopes;
         }
-        if (!empty($required_scopes) && !$token->hasScopes($required_scopes)) {
+        if (!empty($required_scopes) && !$authorize_result->getJwtToken()->hasScopes($required_scopes)) {
             throw new InsufficientScopeException($required_scopes);
         }
 
-        return $token;
-    }
-
-    /**
-     * Set-Cookie Middleware: access token(ridi-at), refresh token(ridi-rt)
-     *
-     * @param TokenData $token_data
-     * @return \Closure
-     */
-    private function setTokenCookiesMiddleware(TokenData $token_data)
-    {
-        return function (Request $request, Response $response, Application $app) use ($token_data) {
-            $access_token_cookie = new Cookie(
-                AccessTokenConstant::ACCESS_TOKEN_COOKIE_KEY,
-                $token_data->getAccessToken()->getToken(),
-                time() + $token_data->getAccessToken()->getExpiresIn(),
-                '/',
-                $app[OAuth2ProviderKeyConstant::TOKEN_COOKIE_DOMAIN],
-                true,
-                true
-            );
-            $response->headers->setCookie($access_token_cookie);
-
-            $refresh_token_cookie = new Cookie(
-                AccessTokenConstant::REFRESH_TOKEN_COOKIE_KEY,
-                $token_data->getRefreshToken()->getToken(),
-                time() + $token_data->getRefreshToken()->getExpiresIn(),
-                '/',
-                $app[OAuth2ProviderKeyConstant::TOKEN_COOKIE_DOMAIN],
-                true,
-                true
-            );
-            $response->headers->setCookie($refresh_token_cookie);
-        };
+        return $authorize_result;
     }
 }

--- a/lib/Authorization/Authorizer.php
+++ b/lib/Authorization/Authorizer.php
@@ -1,16 +1,20 @@
 <?php declare(strict_types=1);
 
-
 namespace Ridibooks\OAuth2\Authorization;
 
-
-use Ridibooks\OAuth2\Authorization\Exception\AuthorizationException;
+use Ridibooks\OAuth2\Authorization\Exception\ExpiredTokenException;
 use Ridibooks\OAuth2\Authorization\Exception\InsufficientScopeException;
 use Ridibooks\OAuth2\Authorization\Exception\TokenNotFoundException;
 use Ridibooks\OAuth2\Authorization\Token\JwtToken;
 use Ridibooks\OAuth2\Authorization\Validator\JwtTokenValidator;
 use Ridibooks\OAuth2\Constant\AccessTokenConstant;
+use Ridibooks\OAuth2\Grant\DataTransferObject\TokenData;
+use Ridibooks\OAuth2\Grant\Granter;
+use Ridibooks\OAuth2\Silex\Constant\OAuth2ProviderKeyConstant;
+use Silex\Application;
+use Symfony\Component\HttpFoundation\Cookie;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
 
 class Authorizer
 {
@@ -25,19 +29,30 @@ class Authorizer
         $this->default_scopes = $default_scopes;
     }
 
-    /**
-     * @param Request $request
-     * @param array $required_scopes
-     * @return JwtToken if the given request is authorized successfully
-     * @throws AuthorizationException
-     * @throws TokenNotFoundException if there is no access_token in the given request
-     * @throws InsufficientScopeException
-     */
-    public function authorize(Request $request, array $required_scopes = []): JwtToken
+    public function authorize(Request $request, Application $app, array $required_scopes = [], bool $use_refreshing_access_token = false): JwtToken
     {
         $access_token = $request->cookies->get(AccessTokenConstant::ACCESS_TOKEN_COOKIE_KEY);
+
         // 1. Validate access_token
-        $token = $this->token_validator->validateToken($access_token);
+        try {
+            $token = $this->token_validator->validateToken($access_token);
+        } catch (TokenNotFoundException | ExpiredTokenException $e) {
+            $refresh_token = $request->cookies->get(AccessTokenConstant::REFRESH_TOKEN_COOKIE_KEY);
+
+            // Refresh access token if requested
+            if ($use_refreshing_access_token && !empty($refresh_token)) {
+                /** @var Granter $granter */
+                $granter = $app[OAuth2ProviderKeyConstant::GRANTER];
+
+                $token_data = $granter->refresh($refresh_token);
+                $token = $this->token_validator->validateToken($token_data->getAccessToken()->getToken());
+
+                $app->after($this->setTokenCookiesMiddleware($token_data));
+            } else {
+                throw $e;
+            }
+        }
+
         // 2. Check scope
         if (empty($required_scopes)) {
             $required_scopes = $this->default_scopes;
@@ -47,5 +62,38 @@ class Authorizer
         }
 
         return $token;
+    }
+
+    /**
+     * Set-Cookie Middleware: access token(ridi-at), refresh token(ridi-rt)
+     *
+     * @param TokenData $token_data
+     * @return \Closure
+     */
+    private function setTokenCookiesMiddleware(TokenData $token_data)
+    {
+        return function (Request $request, Response $response, Application $app) use ($token_data) {
+            $access_token_cookie = new Cookie(
+                AccessTokenConstant::ACCESS_TOKEN_COOKIE_KEY,
+                $token_data->getAccessToken()->getToken(),
+                time() + $token_data->getAccessToken()->getExpiresIn(),
+                '/',
+                $app[OAuth2ProviderKeyConstant::TOKEN_COOKIE_DOMAIN],
+                true,
+                true
+            );
+            $response->headers->setCookie($access_token_cookie);
+
+            $refresh_token_cookie = new Cookie(
+                AccessTokenConstant::REFRESH_TOKEN_COOKIE_KEY,
+                $token_data->getRefreshToken()->getToken(),
+                time() + $token_data->getRefreshToken()->getExpiresIn(),
+                '/',
+                $app[OAuth2ProviderKeyConstant::TOKEN_COOKIE_DOMAIN],
+                true,
+                true
+            );
+            $response->headers->setCookie($refresh_token_cookie);
+        };
     }
 }

--- a/lib/Authorization/Authorizer.php
+++ b/lib/Authorization/Authorizer.php
@@ -33,14 +33,14 @@ class Authorizer
         // 1. Validate access_token
         try {
             $token = $this->token_validator->validateToken($access_token);
-            $authorize_result = AuthorizeResult::createForAuthorizedToken($token);
+            $authorize_result = AuthorizeResult::createFromAuthorizedToken($token);
         } catch (TokenNotFoundException | ExpiredTokenException $e) {
             // Refresh access token if requested
             if ($use_refreshing_access_token && !empty($refresh_token)) {
                 $token_data = $this->granter->refresh($refresh_token);
                 $token = $this->token_validator->validateToken($token_data->getAccessToken()->getToken());
 
-                $authorize_result = AuthorizeResult::createForRefreshedAndAuthorizedToken($token, $token_data);
+                $authorize_result = AuthorizeResult::createFromRefreshedAndAuthorizedToken($token, $token_data);
             } else {
                 throw $e;
             }

--- a/lib/Authorization/Validator/JwtTokenValidator.php
+++ b/lib/Authorization/Validator/JwtTokenValidator.php
@@ -36,8 +36,10 @@ class JwtTokenValidator
     /**
      * @param string|null $access_token
      * @return JwtToken
-     * @throws AuthorizationException
+     * @throws ExpiredTokenException
+     * @throws InvalidJwtException
      * @throws TokenNotFoundException
+     * @throws \Ridibooks\OAuth2\Authorization\Exception\InvalidTokenException
      */
     public function validateToken($access_token): JwtToken
     {

--- a/lib/Constant/AccessTokenConstant.php
+++ b/lib/Constant/AccessTokenConstant.php
@@ -5,6 +5,7 @@ class AccessTokenConstant
 {
     const ACCESS_TOKEN_INFO_KEY = 'access_token_info';
     const ACCESS_TOKEN_COOKIE_KEY = 'ridi-at';
+    const REFRESH_TOKEN_COOKIE_KEY = 'ridi-rt';
 
     const DEFAULT_EXPIRE_MARGIN = 60 * 5;   // seconds
 }

--- a/lib/Silex/Constant/OAuth2ProviderKeyConstant.php
+++ b/lib/Silex/Constant/OAuth2ProviderKeyConstant.php
@@ -10,6 +10,8 @@ class OAuth2ProviderKeyConstant
     const CLIENT_DEFAULT_SCOPE = 'ridi.oauth2.default_scope';
     const CLIENT_DEFAULT_REDIRECT_URI = 'ridi.oauth2.default_redirect_uri';
 
+    const TOKEN_COOKIE_DOMAIN = 'ridi.oauth2.token_cookie_domain';
+
     const AUTHORIZE_URL = 'ridi.oauth2.authorize_url';
     const TOKEN_URL = 'ridi.oauth2.token_url';
     const USER_INFO_URL = 'ridi.oauth2.user_info_url';

--- a/lib/Silex/Provider/OAuth2MiddlewareFactory.php
+++ b/lib/Silex/Provider/OAuth2MiddlewareFactory.php
@@ -24,17 +24,21 @@ class OAuth2MiddlewareFactory
         $this->default_user_provider = $app[OAuth2ProviderKeyConstant::DEFAULT_USER_PROVIDER];
     }
 
-    public function authorize(array $required_scopes = [], OAuth2ExceptionHandlerInterface $exception_handler = null, UserProviderInterface $user_provider = null)
-    {
+    public function authorize(
+        array $required_scopes = [],
+        OAuth2ExceptionHandlerInterface $exception_handler = null,
+        UserProviderInterface $user_provider = null,
+        $use_refreshing_access_token = false
+    ) {
         if ($exception_handler === null) {
             $exception_handler = $this->default_exception_handler;
         }
         if ($user_provider === null) {
             $user_provider = $this->default_user_provider;
         }
-        return function (Request $request, Application $app) use ($required_scopes, $exception_handler, $user_provider) {
+        return function (Request $request, Application $app) use ($required_scopes, $exception_handler, $user_provider, $use_refreshing_access_token) {
             try {
-                $token = $this->authorizer->authorize($request, $required_scopes);
+                $token = $this->authorizer->authorize($request, $app, $required_scopes, $use_refreshing_access_token);
 
                 if (isset($user_provider)) {
                     $user = $user_provider->getUser($token, $request, $app);

--- a/lib/Silex/Provider/OAuth2ServiceProvider.php
+++ b/lib/Silex/Provider/OAuth2ServiceProvider.php
@@ -119,10 +119,11 @@ class OAuth2ServiceProvider implements ServiceProviderInterface
             $jwt_secret = $app[OAuth2ProviderKeyConstant::JWT_SECRET];
             $jwt_expire_term = $app[OAuth2ProviderKeyConstant::JWT_EXPIRE_TERM];
 
-            $client_default_scope = $app[OAuth2ProviderKeyConstant::CLIENT_DEFAULT_SCOPE];
             $jwt_token_validator = new JwtTokenValidator($jwt_secret, $jwt_algorithm, $jwt_expire_term);
+            $granter = $app[OAuth2ProviderKeyConstant::GRANTER];
+            $client_default_scope = $app[OAuth2ProviderKeyConstant::CLIENT_DEFAULT_SCOPE];
 
-            return new Authorizer($jwt_token_validator, $client_default_scope);
+            return new Authorizer($jwt_token_validator, $granter, $client_default_scope);
         };
 
         $app[OAuth2ProviderKeyConstant::MIDDLEWARE] = $app->share(function ($app) {

--- a/lib/Silex/Provider/OAuth2ServiceProvider.php
+++ b/lib/Silex/Provider/OAuth2ServiceProvider.php
@@ -77,6 +77,8 @@ class OAuth2ServiceProvider implements ServiceProviderInterface
         $app[OAuth2ProviderKeyConstant::CLIENT_DEFAULT_SCOPE] = [];
         $app[OAuth2ProviderKeyConstant::CLIENT_DEFAULT_REDIRECT_URI] = null;
 
+        $app[OAuth2ProviderKeyConstant::TOKEN_COOKIE_DOMAIN] = '.ridibooks.com';
+
         $app[OAuth2ProviderKeyConstant::AUTHORIZE_URL] = 'https://account.ridibooks.com/oauth2/authorize/';
         $app[OAuth2ProviderKeyConstant::TOKEN_URL] = 'https://account.ridibooks.com/oauth2/token/';
         $app[OAuth2ProviderKeyConstant::USER_INFO_URL] = 'https://account.ridibooks.com/accounts/me/';

--- a/tests/Authorization/AuthorizerTest.php
+++ b/tests/Authorization/AuthorizerTest.php
@@ -44,8 +44,12 @@ class AuthorizerTest extends TestCase
         $app->get('/', function (Application $app, Request $request) {
             /** @var Authorizer $authorizer */
             $authorizer = $app[OAuth2ProviderKeyConstant::AUTHORIZER];
-            $token = $authorizer->authorize($request);
-            return $token->getSubject();
+
+            $access_token = $request->cookies->get(AccessTokenConstant::ACCESS_TOKEN_COOKIE_KEY);
+            $refresh_token = $request->cookies->get(AccessTokenConstant::REFRESH_TOKEN_COOKIE_KEY);
+
+            $authorize_result = $authorizer->authorize($access_token, $refresh_token);
+            return $authorize_result->getJwtToken()->getSubject();
         });
 
         $access_token = TokenConstant::TOKEN_VALID;
@@ -64,8 +68,12 @@ class AuthorizerTest extends TestCase
             /** @var Authorizer $authorizer */
             $authorizer = $app[OAuth2ProviderKeyConstant::AUTHORIZER];
             try {
-                $token = $authorizer->authorize($request);
-                return $token->getSubject();
+                $access_token = $request->cookies->get(AccessTokenConstant::ACCESS_TOKEN_COOKIE_KEY);
+                $refresh_token = $request->cookies->get(AccessTokenConstant::REFRESH_TOKEN_COOKIE_KEY);
+
+                $authorize_result = $authorizer->authorize($access_token, $refresh_token);
+
+                return $authorize_result->getJwtToken()->getSubject();
             } catch (AuthorizationException $e) {
                 $app->abort(401);
             }


### PR DESCRIPTION
## 변경사항
* `OAuth2MiddlewareFactory::authorize()` 호출 시 refresh token을 이용한 access token 갱신 처리 여부 지정 가능
* `Authorizer`의 Silex에 대한 의존성 제거

## 고민되었던 부분

1. `Authorizer`가 Symfony의 `Application` 객체를 참조하는 것이 옳은가?
2. 토큰 갱신 시 갱신된 토큰 정보를 쿠키에 세팅해주는 after middleware를 무조건 추가했을 때 발생할 수 있는 문제가 있는가?

위 2개의 이슈 중 1번은 `Authorizer::authorize()`가 `AuthorizeResult`라는 객체를 리턴해주면 `OAuth2MiddlewareFactory::authorize()`에서 필요한 처리(2번)를 하는 구조로 변경했습니다.

1, 2번에 대한 의견이 듣고 싶습니다. :)

## 하위 호환성 문제
* `OAuth2MiddlewareFactory::authorize()`를 호출하는 경우는 문제가 없지만 `$app[OAuth2ProviderKeyConstant::AUTHORIZER]`으로 직접 `Authorizer`를 참조하는 경우 파라미터 변경에 따른 하위 호환성 문제가 발생합니다. 서점 코드에서 이런 형태로 사용하는 경우를 확인했습니다.