### PR TITLE
Symfony 4용 OAuth2 Service Provider 추가

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: php
 php:
-  - 7.1.0
+  - 7.1.3
 
 install:
   - make install

--- a/Makefile
+++ b/Makefile
@@ -4,10 +4,15 @@ help:
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
 
 install:
+	@composer install --working-dir=lib/Silex
+	@composer install --working-dir=lib/Symfony
 	@composer install
 
 update:
+	@composer update --working-dir=lib/Silex
+	@composer update --working-dir=lib/Symfony
 	@composer update
 
 test:
-	@./vendor/bin/phpunit tests
+	@lib/Silex/vendor/bin/phpunit
+	@lib/Symfony/vendor/bin/phpunit --bootstrap tests/Symfony/index.php tests/Symfony

--- a/README.md
+++ b/README.md
@@ -170,6 +170,7 @@ o_auth2_service_provider:
   user_info_url: https://account.dev.ridi.io/accounts/me/
   token_cookie_domain: .ridi.io
   jwt_secret: '%env(JWT_SECRET)%'
+  default_exception_handler: Ridibooks\OAuth2\Example\DefaultExceptionHandler
 ```
 
 ```yaml

--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ $app->get('/', function (Application $app, Request $request) {
 });
 ```
 
-## Usage: with Symfony Provider
+## Usage: with Symfony Bundle
 
 ### Services
 - **`Granter()`**
@@ -157,17 +157,19 @@ return [
 ```
 
 ##### 2. Parameter 및 Service 설정
+- '%env(VARIABLE)%'을 이용해 environment variable을 이용할 수 있습니다. 
+
 ```yaml
 # example: <project_root>/config/packages/o_auth2_service_provider.yml
 
 o_auth2_service_provider:
-  client_id: iax7OcCuYJ8Su5p9swjs7RNosL7zYZ4zdV5xyHVx
-  client_secret: vk31iDFzVM1EKQySvkp46TUNjWn9Bvc1wv7CLSwEWzAUDz5GA3iN0QjGktVXi53KCHxIcfq3V62q9aSQkWzB1zx8Um6OWYO4nEqtJYj4uPHnhjDKW7tV4zGeW9yygvZx
+  client_id: '%env(CLIENT_ID)%'
+  client_secret: '%env(CLIENT_SECRET)%'
   authorize_url: https://account.dev.ridi.io/ridi/authorize/
   token_url: https://account.dev.ridi.io/oauth2/token/
   user_info_url: https://account.dev.ridi.io/accounts/me/
   token_cookie_domain: .ridi.io
-  jwt_secret: secret
+  jwt_secret: '%env(JWT_SECRET)%'
 ```
 
 ```yaml

--- a/README.md
+++ b/README.md
@@ -157,7 +157,22 @@ return [
 ```
 
 ##### 2. Parameter 및 Service 설정
-- '%env(VARIABLE)%'을 이용해 environment variable을 이용할 수 있습니다. 
+- '%env(VARIABLE)%'을 이용해 environment variable을 이용할 수 있습니다.
+- Required
+  - client_id
+  - client_secret
+  - authorize_url
+  - token_url
+  - user_info_url
+  - token_cookie_domain
+  - jwt_secret
+  - default_exception_handler
+- optional
+  - client_default_scope
+  - client_default_redirect_uri
+  - jwt_algorithm
+  - jwt_expire_term
+  - default_user_provider
 
 ```yaml
 # example: <project_root>/config/packages/o_auth2_service_provider.yml
@@ -212,7 +227,7 @@ class ExampleController extends Controller
 
     /**
      * @Route("/oauth2", methods={"GET"})
-     * @OAuth2(exception_handler="Ridibooks\OAuth2\Example\ExampleExceptionHandler")
+     * @OAuth2()
      *
      * @param Request $request
      * @return Response
@@ -231,7 +246,7 @@ class ExampleController extends Controller
 
 #### OAuth2 Exception Handler 설정
 - Exception Handler는 OAuth2 과정 중, 오류 발생 시 Exception 상황을 처리하는 역할을 담당합니다. 
-- `OAuth2Middleware`를 이용하려는 경우, Exception Handler는 반드시 지정이 필요합니다.
+- Application Controller에서 `default_exception_handler` 파라미터로 지정한 Exception Handler가 아닌 별도의 Exception Handler를 이용하려는 경우, 아래 절차를 따릅니다.
     - `Ridibooks\OAuth2\Symfony\Handler\OAuth2ExceptionHandlerInterface`를 implement한 Exception Handler를 생성합니다.
          - example: `Ridibooks\Test\OAuth2\Symfony\TestExceptionHandler`
     - Application Controller의 `@OAuth2` Annotation에서 `exception_handler` 속성을 지정합니다.
@@ -239,8 +254,8 @@ class ExampleController extends Controller
 
 #### Custom User Provider 설정
 - User Provider는 인증 이후, User 정보를 가져오는 역할을 담당합니다.
-- 별도의 User Provider를 지정하지 않으면, `Ridibooks\OAuth2\Symfony\Provider\DefaultUserProvider`를 이용합니다.
-- `DefaultUserProvider`가 아닌 다른 User Provider를 이용하려는 경우, 아래 절차를 따릅니다.
+- `default_user_provider` 파라미터를 지정하지 않은 경우, 기본적으로 `Ridibooks\OAuth2\Symfony\Provider\DefaultUserProvider`를 이용합니다.
+- Application Controller에서 `default_user_provider` 파라미터로 지정한 User Provider가 아닌 별도의 User Provider를 이용하려는 경우, 아래 절차를 따릅니다.
     - `Ridibooks\OAuth2\Symfony\Provider\UserProviderInterface`를 implement한 User Provider를 생성합니다.
     - Application Controller의 `@OAuth2` Annotation에서 `user_provider` 속성을 지정합니다.
 ```php
@@ -280,10 +295,7 @@ class ExampleController extends Controller
 {
     /**
      * @Route("/oauth2", methods={"GET"})
-     * @OAuth2(
-     *   user_provider="Ridibooks\OAuth2\Example\CustomUserProvider",
-     *   exception_handler="Ridibooks\OAuth2\Example\ExampleExceptionHandler"
-     * )
+     * @OAuth2(user_provider="Ridibooks\OAuth2\Example\CustomUserProvider")
      *
      * @param Request $request
      * @return Response

--- a/README.md
+++ b/README.md
@@ -9,15 +9,14 @@
 ## Requirements
 
 - `PHP 7.1` or higher
-- `silex/silex v1.2.x or v1.3.x` (optional)
+- `silex/silex v1.3.x` (optional)
+- `symfony/symfony v4.x.x` (optional)
 - `guzzlehttp/guzzle` (optional)
 
 ## Installation
 
 ```bash
 composer require ridibooks/oauth2
-// If needed
-composer require silex/silex:1.3 guzzlehttp/guzzle
 ```
 
 ## Usage
@@ -127,4 +126,168 @@ $app->get('/', function (Application $app, Request $request) {
 		// handle authorization error ...
 	}
 });
+```
+
+## Usage: with Symfony Provider
+
+### Services
+- **`Granter()`**
+    - `OAuth2ServiceProvider::getGranter()`
+    - `Granter::authorize(string $state, string $redirect_uri = null, array $scope = null): string`: `/authorize`를 위한 URL을 반환
+- **`Authorizer()`**
+    - `OAuth2ServiceProvider::getAuthorizer()`
+	- `Authorizer::autorize(Request $request): JwtToken`: `access_token` 유효성 검사 후 `JwtToken` 객체를 반환
+- **`OAuth2Middleware`**
+	- `OAuth2ServiceProvider::getMiddleware()`
+	- `OAuth2ServiceProvider` 생성 시, Symfony Event Subscriber로 등록
+
+### Example: `OAuth2Middleware` Service
+
+#### Configuration
+- 설정 예시는 `tests/Symfony`에서 살펴볼 수 있습니다.
+
+##### 1. `OAuth2ServiceProviderBundle` 등록
+```php
+# example: <project_root>/config/bundles.php
+
+return [
+    ...,
+    Ridibooks\OAuth2\Symfony\OAuth2ServiceProviderBundle::class => ['all' => true]
+];
+```
+
+##### 2. Parameter 및 Service 설정
+```yaml
+# example: <project_root>/config/packages/o_auth2_service_provider.yml
+
+o_auth2_service_provider:
+  client_id: iax7OcCuYJ8Su5p9swjs7RNosL7zYZ4zdV5xyHVx
+  client_secret: vk31iDFzVM1EKQySvkp46TUNjWn9Bvc1wv7CLSwEWzAUDz5GA3iN0QjGktVXi53KCHxIcfq3V62q9aSQkWzB1zx8Um6OWYO4nEqtJYj4uPHnhjDKW7tV4zGeW9yygvZx
+  authorize_url: https://account.dev.ridi.io/ridi/authorize/
+  token_url: https://account.dev.ridi.io/oauth2/token/
+  user_info_url: https://account.dev.ridi.io/accounts/me/
+  token_cookie_domain: .ridi.io
+  jwt_secret: secret
+```
+
+```yaml
+# example: <project_root>/config/services.yml
+
+services:
+  Ridibooks\OAuth2\Example\ExampleController:
+    class: Ridibooks\OAuth2\Example\ExampleController
+    autowire: true
+    autoconfigure: true
+    public: false
+    arguments:
+      - '@oauth2_service_provider'
+```
+
+##### 3. Controller 설정
+```php
+namespace Ridibooks\OAuth2\Example;
+
+use Ridibooks\OAuth2\Symfony\Annotation\OAuth2;
+use Ridibooks\OAuth2\Symfony\Provider\OAuth2ServiceProvider;
+use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Routing\Annotation\Route;
+
+class ExampleController extends Controller
+{
+    /** @var OAuth2ServiceProvider */
+    private $oauth2_service_provider;
+
+    /**
+     * @param OAuth2ServiceProvider $oauth2_service_provider
+     */
+    public function __construct(OAuth2ServiceProvider $oauth2_service_provider)
+    {
+        $this->oauth2_service_provider = $oauth2_service_provider;
+    }
+
+    /**
+     * @Route("/oauth2", methods={"GET"})
+     * @OAuth2(exception_handler="Ridibooks\OAuth2\Example\ExampleExceptionHandler")
+     *
+     * @param Request $request
+     * @return Response
+     */
+    public function normal(Request $request): Response
+    {
+        $user = $this->oauth2_service_provider->getMiddleware()->getUser();
+
+        return new JsonResponse([
+            'u_idx' => $user->getUidx(),
+            'u_id' => $user->getUid()
+        ]);
+    }
+}
+```
+
+#### OAuth2 Exception Handler 설정
+- Exception Handler는 OAuth2 과정 중, 오류 발생 시 Exception 상황을 처리하는 역할을 담당합니다. 
+- `OAuth2Middleware`를 이용하려는 경우, Exception Handler는 반드시 지정이 필요합니다.
+    - `Ridibooks\OAuth2\Symfony\Handler\OAuth2ExceptionHandlerInterface`를 implement한 Exception Handler를 생성합니다.
+         - example: `Ridibooks\Test\OAuth2\Symfony\TestExceptionHandler`
+    - Application Controller의 `@OAuth2` Annotation에서 `exception_handler` 속성을 지정합니다.
+         - example: `@OAuth2(exception_handler="Ridibooks\Test\OAuth2\Symfony\TestExceptionHandler")`
+
+#### Custom User Provider 설정
+- User Provider는 인증 이후, User 정보를 가져오는 역할을 담당합니다.
+- 별도의 User Provider를 지정하지 않으면, `Ridibooks\OAuth2\Symfony\Provider\DefaultUserProvider`를 이용합니다.
+- `DefaultUserProvider`가 아닌 다른 User Provider를 이용하려는 경우, 아래 절차를 따릅니다.
+    - `Ridibooks\OAuth2\Symfony\Provider\UserProviderInterface`를 implement한 User Provider를 생성합니다.
+    - Application Controller의 `@OAuth2` Annotation에서 `user_provider` 속성을 지정합니다.
+```php
+namespace Ridibooks\OAuth2\Example;
+
+use Ridibooks\OAuth2\Authorization\Token\JwtToken;
+use Ridibooks\OAuth2\Symfony\Provider\OAuth2ServiceProvider;
+use Ridibooks\OAuth2\Symfony\Provider\UserProviderInterface;
+use Symfony\Component\HttpFoundation\Request;
+
+class CustomUserProvider implement UserProviderInterface
+{
+    /**
+     * @param JwtToken $token
+     * @param Request $request
+     * @param OAuth2ServiceProvider $oauth2_service_provider
+     * @return User
+     */
+    public function getUser(JwtToken $token, Request $request, OAuth2ServiceProvider $oauth2_service_provider): User
+    {
+        ...
+    }
+}
+```
+
+```php
+namespace Ridibooks\OAuth2\Example;
+
+use Ridibooks\OAuth2\Symfony\Annotation\OAuth2;
+use Ridibooks\OAuth2\Symfony\Provider\OAuth2ServiceProvider;
+use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Routing\Annotation\Route;
+
+class ExampleController extends Controller
+{
+    /**
+     * @Route("/oauth2", methods={"GET"})
+     * @OAuth2(
+     *   user_provider="Ridibooks\OAuth2\Example\CustomUserProvider",
+     *   exception_handler="Ridibooks\OAuth2\Example\ExampleExceptionHandler"
+     * )
+     *
+     * @param Request $request
+     * @return Response
+     */
+    public function normal(Request $request): Response
+    {
+        ...
+    }
+}
 ```

--- a/composer.json
+++ b/composer.json
@@ -1,31 +1,22 @@
 {
-  "name": "ridibooks/oauth2",
-  "description": "Ridibooks OAuth2",
-  "type": "library",
-  "license": "MIT",
-  "require": {
-    "firebase/php-jwt": "^4.0 || ^5.0"
-  },
-  "require-dev": {
-    "silex/silex": "^1.3",
-    "guzzlehttp/guzzle": "^6.3",
-    "phpunit/phpunit": "^6"
-  },
-  "suggest": {
-    "silex/silex": "Required when using `OAuth2ServiceProvider`(compatible with `1.x.x` version)",
-    "guzzlehttp/guzzle": "Required when using `OAuth2ServiceProvider` and `DefaultUserProvider`"
-  },
-  "autoload": {
-    "psr-4": {
-      "Ridibooks\\OAuth2\\": "lib"
+    "name": "ridibooks/oauth2",
+    "description": "Ridibooks OAuth2",
+    "type": "library",
+    "license": "MIT",
+    "autoload": {
+        "psr-4": {
+            "Ridibooks\\OAuth2\\": "lib"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Ridibooks\\Test\\OAuth2\\": "tests"
+        }
+    },
+    "require": {
+        "firebase/php-jwt": "^4.0|^5.0"
+    },
+    "require-dev": {
+        "phpunit/phpunit": "^7"
     }
-  },
-  "autoload-dev": {
-    "psr-4": {
-      "Ridibooks\\Test\\OAuth2\\": "tests"
-    }
-  },
-  "scripts": {
-    "test": "phpunit tests"
-  }
 }

--- a/composer.json
+++ b/composer.json
@@ -20,8 +20,8 @@
         "phpunit/phpunit": "^7"
     },
     "suggest": {
-        "silex/silex": "Required when using `OAuth2ServiceProvider`(compatible with `1.x.x` version)",
-        "symfony/symfony": "Required when using `OAuth2ServiceProviderBundle`",
-        "guzzlehttp/guzzle": "Required when using `OAuth2ServiceProvider` and `DefaultUserProvider` of Silex & Symfony"
+        "silex/silex": "Required when using `Ridibooks\\OAuth2\\Silex\\Provider\\OAuth2ServiceProvider`(compatible with 1.3.x versions)",
+        "symfony/symfony": "Required when using `Ridibooks\\OAuth2\\Symfony\\OAuth2ServiceProviderBundle`(compatible with 4.x.x versions)",
+        "guzzlehttp/guzzle": "Required when using `Ridibooks\\OAuth2\\Silex\\Provider\\DefaultUserProvider`or `Ridibooks\\OAuth2\\Symfony\\Provider\\DefaultUserProvider`"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -18,5 +18,10 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^7"
+    },
+    "suggest": {
+        "silex/silex": "Required when using `OAuth2ServiceProvider`(compatible with `1.x.x` version)",
+        "symfony/symfony": "Required when using `OAuth2ServiceProviderBundle`",
+        "guzzlehttp/guzzle": "Required when using `OAuth2ServiceProvider` and `DefaultUserProvider` of Silex & Symfony"
     }
 }

--- a/lib/Silex/.gitignore
+++ b/lib/Silex/.gitignore
@@ -1,0 +1,2 @@
+vendor/
+composer.lock

--- a/lib/Silex/composer.json
+++ b/lib/Silex/composer.json
@@ -12,11 +12,15 @@
         }
     },
     "require": {
-        "firebase/php-jwt": "^4.0|^5.0",
-        "guzzlehttp/guzzle": "^6.3",
-        "silex/silex": "^1.3"
+        "firebase/php-jwt": "^4.0|^5.0"
     },
     "require-dev": {
+        "guzzlehttp/guzzle": "^6.3",
+        "silex/silex": "^1.3",
         "phpunit/phpunit": "^7"
+    },
+    "suggest": {
+        "silex/silex": "Required when using `OAuth2ServiceProvider`(compatible with `1.x.x` version)",
+        "guzzlehttp/guzzle": "Required when using `OAuth2ServiceProvider` and `DefaultUserProvider`"
     }
 }

--- a/lib/Silex/composer.json
+++ b/lib/Silex/composer.json
@@ -18,9 +18,5 @@
         "guzzlehttp/guzzle": "^6.3",
         "silex/silex": "^1.3",
         "phpunit/phpunit": "^7"
-    },
-    "suggest": {
-        "silex/silex": "Required when using `OAuth2ServiceProvider`(compatible with `1.x.x` version)",
-        "guzzlehttp/guzzle": "Required when using `OAuth2ServiceProvider` and `DefaultUserProvider`"
     }
 }

--- a/lib/Silex/composer.json
+++ b/lib/Silex/composer.json
@@ -1,0 +1,22 @@
+{
+    "name": "ridibooks/silex-oauth2",
+    "description": "Ridibooks OAuth2 for Silex",
+    "autoload": {
+        "psr-4": {
+            "Ridibooks\\OAuth2\\": ".."
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Ridibooks\\Test\\OAuth2\\": "../../tests"
+        }
+    },
+    "require": {
+        "firebase/php-jwt": "^4.0|^5.0",
+        "guzzlehttp/guzzle": "^6.3",
+        "silex/silex": "^1.3"
+    },
+    "require-dev": {
+        "phpunit/phpunit": "^7"
+    }
+}

--- a/lib/Symfony/.gitignore
+++ b/lib/Symfony/.gitignore
@@ -1,0 +1,2 @@
+vendor/
+composer.lock

--- a/lib/Symfony/Annotation/OAuth2.php
+++ b/lib/Symfony/Annotation/OAuth2.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 namespace Ridibooks\OAuth2\Symfony\Annotation;
 
 use Ridibooks\OAuth2\Symfony\Handler\OAuth2ExceptionHandlerInterface;
-use Ridibooks\OAuth2\Symfony\Provider\DefaultUserProvider;
 use Ridibooks\OAuth2\Symfony\Provider\UserProviderInterface;
 use Ridibooks\OAuth2\Symfony\Subscriber\OAuth2Middleware;
 
@@ -22,10 +21,10 @@ class OAuth2
     /** @var string[] */
     private $scopes;
 
-    /** @var UserProviderInterface */
+    /** @var null|string */
     private $user_provider;
 
-    /** @var OAuth2ExceptionHandlerInterface */
+    /** @var null|string */
     private $exception_handler;
 
     /**
@@ -47,17 +46,17 @@ class OAuth2
     }
 
     /**
-     * @return UserProviderInterface
+     * @return null|string
      */
-    public function getUserProvider(): UserProviderInterface
+    public function getUserProvider(): ?string
     {
         return $this->user_provider;
     }
 
     /**
-     * @return OAuth2ExceptionHandlerInterface
+     * @return null|string
      */
-    public function getExceptionHandler(): OAuth2ExceptionHandlerInterface
+    public function getExceptionHandler(): ?string
     {
         return $this->exception_handler;
     }
@@ -80,22 +79,7 @@ class OAuth2
     private function setUserProvider(array $data)
     {
         if (isset($data['user_provider'])) {
-            $user_provider_class = $data['user_provider'];
-
-            try {
-                $reflection_class = new \ReflectionClass($user_provider_class);
-            } catch (\Exception $e) {
-                throw new \InvalidArgumentException('The user_provider is invalid.');
-            }
-
-            $user_provider_interface_class = UserProviderInterface::class;
-            if (!in_array($user_provider_interface_class, $reflection_class->getInterfaceNames())) {
-                throw new \InvalidArgumentException("The user_provider must implement {$user_provider_interface_class}.");
-            }
-
-            $this->user_provider = new $user_provider_class();
-        } else {
-            $this->user_provider = new DefaultUserProvider();
+            $this->user_provider = $data['user_provider'];
         }
     }
 
@@ -104,24 +88,8 @@ class OAuth2
      */
     private function setExceptionHandler(array $data)
     {
-        if (!isset($data['exception_handler'])) {
-            throw new \InvalidArgumentException('The exception_handler is required.');
+        if (isset($data['exception_handler'])) {
+            $this->exception_handler = $data['exception_handler'];
         }
-
-        try {
-            $exception_handler_class = $data['exception_handler'];
-            $reflection_class = new \ReflectionClass($exception_handler_class);
-        } catch (\Exception $e) {
-            throw new \InvalidArgumentException('The exception_handler is invalid.');
-        }
-
-        $exception_handler_interface_class = OAuth2ExceptionHandlerInterface::class;
-        if (!in_array($exception_handler_interface_class, $reflection_class->getInterfaceNames())) {
-            throw new \InvalidArgumentException(
-                "The exception_handler must implement {$exception_handler_interface_class}."
-            );
-        }
-
-        $this->exception_handler = new $exception_handler_class();
     }
 }

--- a/lib/Symfony/Annotation/OAuth2.php
+++ b/lib/Symfony/Annotation/OAuth2.php
@@ -1,0 +1,127 @@
+<?php
+declare(strict_types=1);
+
+namespace Ridibooks\OAuth2\Symfony\Annotation;
+
+use Ridibooks\OAuth2\Symfony\Handler\OAuth2ExceptionHandlerInterface;
+use Ridibooks\OAuth2\Symfony\Provider\DefaultUserProvider;
+use Ridibooks\OAuth2\Symfony\Provider\UserProviderInterface;
+use Ridibooks\OAuth2\Symfony\Subscriber\OAuth2Middleware;
+
+/**
+ * Annotation class for @OAuth2().
+ *
+ * Annotated classes or methods with annotation @OAuth2 use OAuth2Middleware.
+ * @see OAuth2Middleware
+ *
+ * @Annotation
+ * @Target({"CLASS", "METHOD"})
+ */
+class OAuth2
+{
+    /** @var string[] */
+    private $scopes;
+
+    /** @var UserProviderInterface */
+    private $user_provider;
+
+    /** @var OAuth2ExceptionHandlerInterface */
+    private $exception_handler;
+
+    /**
+     * @param array $data
+     */
+    public function __construct(array $data)
+    {
+        $this->setScopes($data);
+        $this->setUserProvider($data);
+        $this->setExceptionHandler($data);
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getScopes(): array
+    {
+        return $this->scopes;
+    }
+
+    /**
+     * @return UserProviderInterface
+     */
+    public function getUserProvider(): UserProviderInterface
+    {
+        return $this->user_provider;
+    }
+
+    /**
+     * @return OAuth2ExceptionHandlerInterface
+     */
+    public function getExceptionHandler(): OAuth2ExceptionHandlerInterface
+    {
+        return $this->exception_handler;
+    }
+
+    /**
+     * @param array $data
+     */
+    private function setScopes(array $data)
+    {
+        if (isset($data['scopes']) && is_array($data['scopes'])) {
+            $this->scopes = $data['scopes'];
+        } else {
+            $this->scopes = [];
+        }
+    }
+
+    /**
+     * @param array $data
+     */
+    private function setUserProvider(array $data)
+    {
+        if (isset($data['user_provider'])) {
+            $user_provider_class = $data['user_provider'];
+
+            try {
+                $reflection_class = new \ReflectionClass($user_provider_class);
+            } catch (\Exception $e) {
+                throw new \InvalidArgumentException('The user_provider is invalid.');
+            }
+
+            $user_provider_interface_class = UserProviderInterface::class;
+            if (!in_array($user_provider_interface_class, $reflection_class->getInterfaceNames())) {
+                throw new \InvalidArgumentException("The user_provider must implement {$user_provider_interface_class}.");
+            }
+
+            $this->user_provider = new $user_provider_class();
+        } else {
+            $this->user_provider = new DefaultUserProvider();
+        }
+    }
+
+    /**
+     * @param array $data
+     */
+    private function setExceptionHandler(array $data)
+    {
+        if (!isset($data['exception_handler'])) {
+            throw new \InvalidArgumentException('The exception_handler is required.');
+        }
+
+        try {
+            $exception_handler_class = $data['exception_handler'];
+            $reflection_class = new \ReflectionClass($exception_handler_class);
+        } catch (\Exception $e) {
+            throw new \InvalidArgumentException('The exception_handler is invalid.');
+        }
+
+        $exception_handler_interface_class = OAuth2ExceptionHandlerInterface::class;
+        if (!in_array($exception_handler_interface_class, $reflection_class->getInterfaceNames())) {
+            throw new \InvalidArgumentException(
+                "The exception_handler must implement {$exception_handler_interface_class}."
+            );
+        }
+
+        $this->exception_handler = new $exception_handler_class();
+    }
+}

--- a/lib/Symfony/DependencyInjection/Configuration.php
+++ b/lib/Symfony/DependencyInjection/Configuration.php
@@ -1,0 +1,66 @@
+<?php
+declare(strict_types=1);
+
+namespace Ridibooks\OAuth2\Symfony\DependencyInjection;
+
+use Symfony\Component\Config\Definition\Builder\TreeBuilder;
+use Symfony\Component\Config\Definition\ConfigurationInterface;
+
+class Configuration implements ConfigurationInterface
+{
+    /**
+     * @return TreeBuilder
+     */
+    public function getConfigTreeBuilder(): TreeBuilder
+    {
+        $tree_builder = new TreeBuilder();
+        $root_node = $tree_builder->root('o_auth2_service_provider');
+
+        $root_node
+            ->children()
+                ->scalarNode('client_id')
+                    ->isRequired()
+                    ->cannotBeEmpty()
+                ->end()
+                ->scalarNode('client_secret')
+                    ->isRequired()
+                    ->cannotBeEmpty()
+                ->end()
+                ->scalarNode('client_default_scope')
+                    ->defaultValue([])
+                ->end()
+                ->scalarNode('client_default_redirect_uri')
+                    ->defaultNull()
+                ->end()
+                ->scalarNode('authorize_url')
+                    ->isRequired()
+                    ->cannotBeEmpty()
+                ->end()
+                ->scalarNode('token_url')
+                    ->isRequired()
+                    ->cannotBeEmpty()
+                ->end()
+                ->scalarNode('user_info_url')
+                    ->isRequired()
+                    ->cannotBeEmpty()
+                ->end()
+                ->scalarNode('token_cookie_domain')
+                    ->isRequired()
+                    ->cannotBeEmpty()
+                ->end()
+                ->scalarNode('jwt_algorithm')
+                    ->cannotBeEmpty()
+                    ->defaultValue('HS256')
+                ->end()
+                ->scalarNode('jwt_secret')
+                    ->isRequired()
+                    ->cannotBeEmpty()
+                ->end()
+                ->integerNode('jwt_expire_term')
+                    ->defaultValue(5 * 60)
+                ->end()
+            ->end();
+
+        return $tree_builder;
+    }
+}

--- a/lib/Symfony/DependencyInjection/Configuration.php
+++ b/lib/Symfony/DependencyInjection/Configuration.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace Ridibooks\OAuth2\Symfony\DependencyInjection;
 
+use Ridibooks\OAuth2\Symfony\Provider\DefaultUserProvider;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
 
@@ -58,6 +59,14 @@ class Configuration implements ConfigurationInterface
                 ->end()
                 ->integerNode('jwt_expire_term')
                     ->defaultValue(5 * 60)
+                ->end()
+                ->scalarNode('default_user_provider')
+                    ->cannotBeEmpty()
+                    ->defaultValue(DefaultUserProvider::class)
+                ->end()
+                ->scalarNode('default_exception_handler')
+                    ->isRequired()
+                    ->cannotBeEmpty()
                 ->end()
             ->end();
 

--- a/lib/Symfony/DependencyInjection/OAuth2ServiceProviderExtension.php
+++ b/lib/Symfony/DependencyInjection/OAuth2ServiceProviderExtension.php
@@ -1,0 +1,28 @@
+<?php
+declare(strict_types=1);
+
+namespace Ridibooks\OAuth2\Symfony\DependencyInjection;
+
+use Symfony\Component\Config\FileLocator;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
+use Symfony\Component\HttpKernel\DependencyInjection\Extension;
+
+class OAuth2ServiceProviderExtension extends Extension
+{
+    /**
+     * @param array $configs
+     * @param ContainerBuilder $container
+     * @throws \Exception
+     */
+    public function load(array $configs, ContainerBuilder $container): void
+    {
+        $container->setParameter(
+            $this->getAlias(),
+            $this->processConfiguration(new Configuration(), $configs)
+        );
+
+        $loader = new YamlFileLoader($container, new FileLocator(__DIR__ . '/../Resources/config'));
+        $loader->load('services.yml');
+    }
+}

--- a/lib/Symfony/Handler/OAuth2ExceptionHandlerInterface.php
+++ b/lib/Symfony/Handler/OAuth2ExceptionHandlerInterface.php
@@ -1,0 +1,24 @@
+<?php
+declare(strict_types=1);
+
+namespace Ridibooks\OAuth2\Symfony\Handler;
+
+use Ridibooks\OAuth2\Authorization\Exception\AuthorizationException;
+use Ridibooks\OAuth2\Symfony\Provider\OAuth2ServiceProvider;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+interface OAuth2ExceptionHandlerInterface
+{
+    /**
+     * @param AuthorizationException $e
+     * @param Request $request
+     * @param OAuth2ServiceProvider $oauth2_service_provider
+     * @return null|Response
+     */
+    public function handle(
+        AuthorizationException $e,
+        Request $request,
+        OAuth2ServiceProvider $oauth2_service_provider
+    ): ?Response;
+}

--- a/lib/Symfony/OAuth2ServiceProviderBundle.php
+++ b/lib/Symfony/OAuth2ServiceProviderBundle.php
@@ -1,0 +1,10 @@
+<?php
+declare(strict_types=1);
+
+namespace Ridibooks\OAuth2\Symfony;
+
+use Symfony\Component\HttpKernel\Bundle\Bundle;
+
+class OAuth2ServiceProviderBundle extends Bundle
+{
+}

--- a/lib/Symfony/Provider/DefaultUserProvider.php
+++ b/lib/Symfony/Provider/DefaultUserProvider.php
@@ -1,0 +1,65 @@
+<?php
+declare(strict_types=1);
+
+namespace Ridibooks\OAuth2\Symfony\Provider;
+
+use GuzzleHttp\Client;
+use GuzzleHttp\Cookie\CookieJar;
+use GuzzleHttp\Exception\BadResponseException;
+use Ridibooks\OAuth2\Authorization\Exception\AuthorizationException;
+use Ridibooks\OAuth2\Authorization\Exception\TokenNotFoundException;
+use Ridibooks\OAuth2\Authorization\Exception\UserNotFoundException;
+use Ridibooks\OAuth2\Authorization\Token\JwtToken;
+use Ridibooks\OAuth2\Constant\AccessTokenConstant;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class DefaultUserProvider implements UserProviderInterface
+{
+    /**
+     * @param JwtToken $token
+     * @param Request $request
+     * @param OAuth2ServiceProvider $oauth2_service_provider
+     * @return User
+     * @throws AuthorizationException
+     * @throws TokenNotFoundException
+     * @throws UserNotFoundException
+     */
+    public function getUser(JwtToken $token, Request $request, OAuth2ServiceProvider $oauth2_service_provider): User
+    {
+        $access_token = $request->cookies->get(AccessTokenConstant::ACCESS_TOKEN_COOKIE_KEY);
+        if (is_null($access_token)) {
+            throw new TokenNotFoundException();
+        }
+
+        $cookie_jar = CookieJar::fromArray(
+            [AccessTokenConstant::ACCESS_TOKEN_COOKIE_KEY => $access_token],
+            $oauth2_service_provider->getConfigs()['token_cookie_domain']
+        );
+
+        try {
+            $client = new Client();
+            $response = $client->get(
+                $oauth2_service_provider->getConfigs()['user_info_url'],
+                [
+                    'cookies' => $cookie_jar,
+                    'headers' => ['Accept' => 'application/json']
+                ]
+            );
+            $content = $response->getBody()->getContents();
+        } catch (BadResponseException $e) {
+            $status = $e->getResponse()->getStatusCode();
+            if ($status === Response::HTTP_UNAUTHORIZED) {
+                throw new AuthorizationException('Unauthorized access token');
+            }
+            if ($status === Response::HTTP_NOT_FOUND) {
+                throw new UserNotFoundException();
+            }
+            throw new AuthorizationException($e->getMessage());
+        } catch (\Exception $e) {
+            throw new AuthorizationException($e->getMessage());
+        }
+
+        return new User($content);
+    }
+}

--- a/lib/Symfony/Provider/OAuth2ServiceProvider.php
+++ b/lib/Symfony/Provider/OAuth2ServiceProvider.php
@@ -1,0 +1,108 @@
+<?php
+declare(strict_types=1);
+
+namespace Ridibooks\OAuth2\Symfony\Provider;
+
+use Doctrine\Common\Annotations\CachedReader;
+use Ridibooks\OAuth2\Authorization\Authorizer;
+use Ridibooks\OAuth2\Authorization\Validator\JwtTokenValidator;
+use Ridibooks\OAuth2\Grant\DataTransferObject\AuthorizationServerInfo;
+use Ridibooks\OAuth2\Grant\DataTransferObject\ClientInfo;
+use Ridibooks\OAuth2\Grant\Granter;
+use Ridibooks\OAuth2\Symfony\Subscriber\OAuth2Middleware;
+use Symfony\Component\EventDispatcher\EventDispatcher;
+
+class OAuth2ServiceProvider
+{
+    /** @var CachedReader */
+    private $annotation_reader;
+
+    /** @var EventDispatcher */
+    private $event_dispatcher;
+
+    /** @var array */
+    private $configs;
+
+    /** @var Granter */
+    private $granter;
+
+    /** @var Authorizer */
+    private $authorizer;
+
+    /** @var OAuth2Middleware */
+    private $middleware;
+
+    /**
+     * @param CachedReader $annotation_reader
+     * @param EventDispatcher $event_dispatcher
+     * @param array $configs
+     */
+    public function __construct(CachedReader $annotation_reader, EventDispatcher $event_dispatcher, array $configs)
+    {
+        $this->annotation_reader = $annotation_reader;
+        $this->event_dispatcher = $event_dispatcher;
+        $this->configs = $configs;
+
+        $this->setGranter();
+        $this->setAuthorizer();
+        $this->setMiddleware();
+    }
+
+    /**
+     * @return array
+     */
+    public function getConfigs(): array
+    {
+        return $this->configs;
+    }
+
+    /**
+     * @return Granter
+     */
+    public function getGranter(): Granter
+    {
+        return $this->granter;
+    }
+
+    /**
+     * @return Authorizer
+     */
+    public function getAuthorizer(): Authorizer
+    {
+        return $this->authorizer;
+    }
+
+    /**
+     * @return OAuth2Middleware
+     */
+    public function getMiddleware(): OAuth2Middleware
+    {
+        return $this->middleware;
+    }
+
+    private function setGranter(): void
+    {
+        $client_info = new ClientInfo($this->configs['client_id'], $this->configs['client_secret']);
+        $auth_server_info = new AuthorizationServerInfo(
+            $this->configs['authorize_url'],
+            $this->configs['token_url']
+        );
+        $this->granter = new Granter($client_info, $auth_server_info);
+    }
+
+    private function setAuthorizer(): void
+    {
+        $jwt_token_validator = new JwtTokenValidator(
+            $this->configs['jwt_secret'],
+            $this->configs['jwt_algorithm'],
+            $this->configs['jwt_expire_term']
+        );
+        $this->authorizer = new Authorizer($jwt_token_validator, $this->configs['client_default_scope']);
+    }
+
+    private function setMiddleware()
+    {
+        $this->middleware = new OAuth2Middleware($this->annotation_reader, $this);
+        $this->event_dispatcher->addSubscriber($this->middleware);
+    }
+}

--- a/lib/Symfony/Provider/User.php
+++ b/lib/Symfony/Provider/User.php
@@ -1,0 +1,47 @@
+<?php
+declare(strict_types=1);
+
+namespace Ridibooks\OAuth2\Symfony\Provider;
+
+use Ridibooks\OAuth2\Authorization\Exception\AuthorizationException;
+
+class User
+{
+    /** @var int */
+    private $u_idx;
+
+    /** @var string */
+    private $u_id;
+
+    /**
+     * @param string $user_info_json
+     * @throws AuthorizationException
+     */
+    public function __construct(string $user_info_json)
+    {
+        $json = json_decode($user_info_json);
+        if (is_null($json) || !isset($json->result)) {
+            throw new AuthorizationException('Invalid user info json response');
+        }
+        $result = $json->result;
+
+        $this->u_idx = $result->idx;
+        $this->u_id = $result->id;
+    }
+
+    /**
+     * @return int
+     */
+    public function getUidx(): int
+    {
+        return $this->u_idx;
+    }
+
+    /**
+     * @return string
+     */
+    public function getUid(): string
+    {
+        return $this->u_id;
+    }
+}

--- a/lib/Symfony/Provider/UserProviderInterface.php
+++ b/lib/Symfony/Provider/UserProviderInterface.php
@@ -1,0 +1,18 @@
+<?php
+declare(strict_types=1);
+
+namespace Ridibooks\OAuth2\Symfony\Provider;
+
+use Ridibooks\OAuth2\Authorization\Token\JwtToken;
+use Symfony\Component\HttpFoundation\Request;
+
+interface UserProviderInterface
+{
+    /**
+     * @param JwtToken $token
+     * @param Request $request
+     * @param OAuth2ServiceProvider $oauth2_service_provider
+     * @return User
+     */
+    public function getUser(JwtToken $token, Request $request, OAuth2ServiceProvider $oauth2_service_provider): User;
+}

--- a/lib/Symfony/Resources/config/services.yml
+++ b/lib/Symfony/Resources/config/services.yml
@@ -1,0 +1,10 @@
+services:
+  oauth2_service_provider:
+    class: Ridibooks\OAuth2\Symfony\Provider\OAuth2ServiceProvider
+    autowire: true
+    autoconfigure: true
+    public: false
+    arguments:
+      - '@annotation_reader'
+      - '@event_dispatcher'
+      - '%o_auth2_service_provider%'

--- a/lib/Symfony/Subscriber/OAuth2Middleware.php
+++ b/lib/Symfony/Subscriber/OAuth2Middleware.php
@@ -6,8 +6,10 @@ namespace Ridibooks\OAuth2\Symfony\Subscriber;
 use Doctrine\Common\Annotations\CachedReader;
 use Ridibooks\OAuth2\Authorization\Exception\AuthorizationException;
 use Ridibooks\OAuth2\Symfony\Annotation\OAuth2;
+use Ridibooks\OAuth2\Symfony\Handler\OAuth2ExceptionHandlerInterface;
 use Ridibooks\OAuth2\Symfony\Provider\OAuth2ServiceProvider;
 use Ridibooks\OAuth2\Symfony\Provider\User;
+use Ridibooks\OAuth2\Symfony\Provider\UserProviderInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Event\FilterControllerEvent;
@@ -65,13 +67,13 @@ class OAuth2Middleware implements EventSubscriberInterface
                 $event->getRequest(),
                 $annotation->getScopes()
             );
-            $this->user = $annotation->getUserProvider()->getUser(
+            $this->user = self::getUserProvider($annotation)->getUser(
                 $token,
                 $event->getRequest(),
                 $this->oauth2_service_provider
             );
         } catch (AuthorizationException $e) {
-            $response = $annotation->getExceptionHandler()->handle(
+            $response = self::getExceptionHandler($annotation)->handle(
                 $e,
                 $event->getRequest(),
                 $this->oauth2_service_provider
@@ -106,5 +108,61 @@ class OAuth2Middleware implements EventSubscriberInterface
         $reflection_method = $reflection_class->getMethod($method_name);
 
         return $this->annotation_reader->getMethodAnnotation($reflection_method, OAuth2::class);
+    }
+
+    /**
+     * @param OAuth2 $annotation
+     * @return UserProviderInterface
+     */
+    private function getUserProvider(OAuth2 $annotation): UserProviderInterface
+    {
+        if (is_null($annotation->getUserProvider())) {
+            $user_provider_class = $this->oauth2_service_provider->getConfigs()['default_user_provider'];
+        } else {
+            $user_provider_class = $annotation->getUserProvider();
+        }
+
+        try {
+            $reflection_class = new \ReflectionClass($user_provider_class);
+        } catch (\Exception $e) {
+            throw new \InvalidArgumentException('The user_provider is invalid.');
+        }
+
+        $user_provider_interface_class = UserProviderInterface::class;
+        if (!in_array($user_provider_interface_class, $reflection_class->getInterfaceNames())) {
+            throw new \InvalidArgumentException(
+                "The user_provider must implement {$user_provider_interface_class}."
+            );
+        }
+
+        return new $user_provider_class();
+    }
+
+    /**
+     * @param OAuth2 $annotation
+     * @return OAuth2ExceptionHandlerInterface
+     */
+    private function getExceptionHandler(OAuth2 $annotation): OAuth2ExceptionHandlerInterface
+    {
+        if (is_null($annotation->getExceptionHandler())) {
+            $exception_handler_class = $this->oauth2_service_provider->getConfigs()['default_exception_handler'];
+        } else {
+            $exception_handler_class = $annotation->getExceptionHandler();
+        }
+
+        try {
+            $reflection_class = new \ReflectionClass($exception_handler_class);
+        } catch (\Exception $e) {
+            throw new \InvalidArgumentException('The exception_handler is invalid.');
+        }
+
+        $exception_handler_interface_class = OAuth2ExceptionHandlerInterface::class;
+        if (!in_array($exception_handler_interface_class, $reflection_class->getInterfaceNames())) {
+            throw new \InvalidArgumentException(
+                "The exception_handler must implement {$exception_handler_interface_class}."
+            );
+        }
+
+        return new $exception_handler_class();
     }
 }

--- a/lib/Symfony/Subscriber/OAuth2Middleware.php
+++ b/lib/Symfony/Subscriber/OAuth2Middleware.php
@@ -1,0 +1,110 @@
+<?php
+declare(strict_types=1);
+
+namespace Ridibooks\OAuth2\Symfony\Subscriber;
+
+use Doctrine\Common\Annotations\CachedReader;
+use Ridibooks\OAuth2\Authorization\Exception\AuthorizationException;
+use Ridibooks\OAuth2\Symfony\Annotation\OAuth2;
+use Ridibooks\OAuth2\Symfony\Provider\OAuth2ServiceProvider;
+use Ridibooks\OAuth2\Symfony\Provider\User;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Event\FilterControllerEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
+
+class OAuth2Middleware implements EventSubscriberInterface
+{
+    /** @var CachedReader */
+    private $annotation_reader;
+
+    /** @var OAuth2ServiceProvider */
+    private $oauth2_service_provider;
+
+    /** @var User */
+    private $user;
+
+    /**
+     * @param CachedReader $annotation_reader
+     * @param OAuth2ServiceProvider $oauth2_service_provider
+     */
+    public function __construct(CachedReader $annotation_reader, OAuth2ServiceProvider $oauth2_service_provider)
+    {
+        $this->annotation_reader = $annotation_reader;
+        $this->oauth2_service_provider = $oauth2_service_provider;
+    }
+
+    /**
+     * @return array
+     */
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            KernelEvents::CONTROLLER => 'onKernelController',
+        ];
+    }
+
+    /**
+     * @param FilterControllerEvent $event
+     * @throws \ReflectionException
+     */
+    public function onKernelController(FilterControllerEvent $event): void
+    {
+        if (!is_array($event->getController())) {
+            return;
+        }
+
+        [$controller, $method_name] = $event->getController();
+        $annotation = $this->getAnnotation($controller, $method_name);
+        if (is_null($annotation)) {
+            return;
+        }
+
+        try {
+            $token = $this->oauth2_service_provider->getAuthorizer()->authorize(
+                $event->getRequest(),
+                $annotation->getScopes()
+            );
+            $this->user = $annotation->getUserProvider()->getUser(
+                $token,
+                $event->getRequest(),
+                $this->oauth2_service_provider
+            );
+        } catch (AuthorizationException $e) {
+            $response = $annotation->getExceptionHandler()->handle(
+                $e,
+                $event->getRequest(),
+                $this->oauth2_service_provider
+            );
+            if ($response instanceof Response) {
+                $event->setController(function () use ($response) {
+                    return $response;
+                });
+            }
+        }
+
+        return;
+    }
+
+    /**
+     * @return User
+     */
+    public function getUser(): User
+    {
+        return $this->user;
+    }
+
+    /**
+     * @param $controller
+     * @param string $method_name
+     * @return null|OAuth2
+     * @throws \ReflectionException
+     */
+    private function getAnnotation($controller, string $method_name): ?OAuth2
+    {
+        $reflection_class = new \ReflectionClass($controller);
+        $reflection_method = $reflection_class->getMethod($method_name);
+
+        return $this->annotation_reader->getMethodAnnotation($reflection_method, OAuth2::class);
+    }
+}

--- a/lib/Symfony/composer.json
+++ b/lib/Symfony/composer.json
@@ -12,12 +12,16 @@
         }
     },
     "require": {
-        "firebase/php-jwt": "^4.0|^5.0",
-        "guzzlehttp/guzzle": "^6.3",
-        "symfony/symfony": "^4.0"
+        "firebase/php-jwt": "^4.0|^5.0"
     },
     "require-dev": {
+        "symfony/symfony": "^4.0",
+        "guzzlehttp/guzzle": "^6.3",
         "phpunit/phpunit": "^7",
         "codeception/aspect-mock": "^3.0"
+    },
+    "suggest": {
+        "symfony/symfony": "Required when using `OAuth2ServiceProviderBundle`",
+        "guzzlehttp/guzzle": "Required when using `OAuth2ServiceProviderBundle` and `DefaultUserProvider`"
     }
 }

--- a/lib/Symfony/composer.json
+++ b/lib/Symfony/composer.json
@@ -19,9 +19,5 @@
         "guzzlehttp/guzzle": "^6.3",
         "phpunit/phpunit": "^7",
         "codeception/aspect-mock": "^3.0"
-    },
-    "suggest": {
-        "symfony/symfony": "Required when using `OAuth2ServiceProviderBundle`",
-        "guzzlehttp/guzzle": "Required when using `OAuth2ServiceProviderBundle` and `DefaultUserProvider`"
     }
 }

--- a/lib/Symfony/composer.json
+++ b/lib/Symfony/composer.json
@@ -1,0 +1,23 @@
+{
+    "name": "ridibooks/symfony-oauth2",
+    "description": "Ridibooks OAuth2 for Symfony",
+    "autoload": {
+        "psr-4": {
+            "Ridibooks\\OAuth2\\": ".."
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Ridibooks\\Test\\OAuth2\\": "../../tests"
+        }
+    },
+    "require": {
+        "firebase/php-jwt": "^4.0|^5.0",
+        "guzzlehttp/guzzle": "^6.3",
+        "symfony/symfony": "^4.0"
+    },
+    "require-dev": {
+        "phpunit/phpunit": "^7",
+        "codeception/aspect-mock": "^3.0"
+    }
+}

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,11 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <phpunit bootstrap="vendor/autoload.php"
- colors="true"
- stderr="true"
+    colors="true"
+    stderr="true"
 >
     <testsuites>
         <testsuite name="Test Suite">
             <directory>./tests</directory>
+            <exclude>./tests/Symfony</exclude>
         </testsuite>
     </testsuites>
 

--- a/tests/Symfony/.gitignore
+++ b/tests/Symfony/.gitignore
@@ -1,0 +1,3 @@
+cache/
+logs/
+aspect_mock/

--- a/tests/Symfony/OAuth2MiddlewareTest.php
+++ b/tests/Symfony/OAuth2MiddlewareTest.php
@@ -1,0 +1,80 @@
+<?php
+declare(strict_types=1);
+
+namespace Ridibooks\Test\OAuth2\Symfony;
+
+use AspectMock\Test as Test;
+use Ridibooks\OAuth2\Authorization\Exception\AuthorizationException;
+use Ridibooks\OAuth2\Constant\AccessTokenConstant;
+use Ridibooks\OAuth2\Symfony\Provider\DefaultUserProvider;
+use Ridibooks\OAuth2\Symfony\Provider\User;
+use Ridibooks\Test\OAuth2\Common\TokenConstant;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Symfony\Component\BrowserKit\Cookie;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class OAuth2MiddlewareTest extends WebTestCase
+{
+    /**
+     * @dataProvider tokenProvider
+     *
+     * @param string $token
+     * @param int $http_status_code
+     * @throws AuthorizationException
+     */
+    public function testMiddleware(string $token, int $http_status_code)
+    {
+        if ($http_status_code === Response::HTTP_OK) {
+            Test::double(
+                DefaultUserProvider::class,
+                [
+                    'getUser' => new User(json_encode([
+                        "result" => [
+                            "id" => TokenConstant::USERNAME,
+                            "idx" => TokenConstant::USER_IDX,
+                            "is_verified_adult" => true,
+                        ],
+                        "message" => "정상적으로 완료되었습니다."
+                    ]))
+                ]
+            );
+        }
+
+        $client = self::createClient();
+        $client->getCookieJar()->set(new Cookie(AccessTokenConstant::ACCESS_TOKEN_COOKIE_KEY, $token));
+        $client->request(
+            Request::METHOD_GET,
+            $token === TokenConstant::TOKEN_HAS_NO_SCOPE ? '/oauth2-scope-test' : '/oauth2'
+        );
+
+        $response_status_code = $client->getResponse()->getStatusCode();
+        $this->assertSame($http_status_code, $response_status_code);
+
+        Test::clean(DefaultUserProvider::class);
+    }
+
+    /**
+     * @return array
+     */
+    public function tokenProvider(): array
+    {
+        return [
+            [TokenConstant::TOKEN_VALID, Response::HTTP_OK],
+            [TokenConstant::TOKEN_EXPIRED, Response::HTTP_UNAUTHORIZED],
+            [TokenConstant::TOKEN_EMPTY, Response::HTTP_UNAUTHORIZED],
+            [TokenConstant::TOKEN_INVALID_PAYLOAD, Response::HTTP_UNAUTHORIZED],
+            [TokenConstant::TOKEN_INVALID_SIGNATURE, Response::HTTP_UNAUTHORIZED],
+            [TokenConstant::TOKEN_HAS_NO_SCOPE, Response::HTTP_FORBIDDEN]
+        ];
+    }
+
+    /**
+     * @param array $options
+     * @return TestKernel
+     */
+    protected static function createKernel(array $options = []): TestKernel
+    {
+        return new TestKernel('test', false);
+    }
+}

--- a/tests/Symfony/TestController.php
+++ b/tests/Symfony/TestController.php
@@ -1,0 +1,62 @@
+<?php
+declare(strict_types=1);
+
+namespace Ridibooks\Test\OAuth2\Symfony;
+
+use Ridibooks\OAuth2\Symfony\Annotation\OAuth2;
+use Ridibooks\OAuth2\Symfony\Provider\OAuth2ServiceProvider;
+use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Routing\Annotation\Route;
+
+class TestController extends Controller
+{
+    /** @var OAuth2ServiceProvider */
+    private $oauth2_service_provider;
+
+    /**
+     * @param OAuth2ServiceProvider $oauth2_service_provider
+     */
+    public function __construct(OAuth2ServiceProvider $oauth2_service_provider)
+    {
+        $this->oauth2_service_provider = $oauth2_service_provider;
+    }
+
+    /**
+     * @Route("/oauth2", methods={"GET"})
+     * @OAuth2(exception_handler="Ridibooks\Test\OAuth2\Symfony\TestExceptionHandler")
+     *
+     * @param Request $request
+     * @return JsonResponse
+     */
+    public function normal(Request $request): JsonResponse
+    {
+        $user = $this->oauth2_service_provider->getMiddleware()->getUser();
+
+        return new JsonResponse([
+            'u_idx' => $user->getUidx(),
+            'u_id' => $user->getUid()
+        ]);
+    }
+
+    /**
+     * @Route("/oauth2-scope-test", methods={"GET"})
+     * @OAuth2(
+     *   scopes={"test_scope"},
+     *   exception_handler="Ridibooks\Test\OAuth2\Symfony\TestExceptionHandler"
+     * )
+     *
+     * @param Request $request
+     * @return JsonResponse
+     */
+    public function scopeTest(Request $request): JsonResponse
+    {
+        $user = $this->oauth2_service_provider->getMiddleware()->getUser();
+
+        return new JsonResponse([
+            'u_idx' => $user->getUidx(),
+            'u_id' => $user->getUid()
+        ]);
+    }
+}

--- a/tests/Symfony/TestController.php
+++ b/tests/Symfony/TestController.php
@@ -25,7 +25,7 @@ class TestController extends Controller
 
     /**
      * @Route("/oauth2", methods={"GET"})
-     * @OAuth2(exception_handler="Ridibooks\Test\OAuth2\Symfony\TestExceptionHandler")
+     * @OAuth2()
      *
      * @param Request $request
      * @return JsonResponse
@@ -42,10 +42,7 @@ class TestController extends Controller
 
     /**
      * @Route("/oauth2-scope-test", methods={"GET"})
-     * @OAuth2(
-     *   scopes={"test_scope"},
-     *   exception_handler="Ridibooks\Test\OAuth2\Symfony\TestExceptionHandler"
-     * )
+     * @OAuth2(scopes={"test_scope"})
      *
      * @param Request $request
      * @return JsonResponse

--- a/tests/Symfony/TestExceptionHandler.php
+++ b/tests/Symfony/TestExceptionHandler.php
@@ -1,0 +1,32 @@
+<?php
+declare(strict_types=1);
+
+namespace Ridibooks\Test\OAuth2\Symfony;
+
+use Ridibooks\OAuth2\Authorization\Exception\AuthorizationException;
+use Ridibooks\OAuth2\Authorization\Exception\InsufficientScopeException;
+use Ridibooks\OAuth2\Symfony\Handler\OAuth2ExceptionHandlerInterface;
+use Ridibooks\OAuth2\Symfony\Provider\OAuth2ServiceProvider;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class TestExceptionHandler implements OAuth2ExceptionHandlerInterface
+{
+    /**
+     * @param AuthorizationException $e
+     * @param Request $request
+     * @param OAuth2ServiceProvider $oauth2_service_provider
+     * @return null|Response
+     */
+    public function handle(
+        AuthorizationException $e,
+        Request $request,
+        OAuth2ServiceProvider $oauth2_service_provider
+    ): ?Response {
+        if ($e instanceof InsufficientScopeException) {
+            return new Response('No sufficient scope.', Response::HTTP_FORBIDDEN);
+        }
+
+        return new Response('Login required.', Response::HTTP_UNAUTHORIZED);
+    }
+}

--- a/tests/Symfony/TestKernel.php
+++ b/tests/Symfony/TestKernel.php
@@ -1,0 +1,45 @@
+<?php
+declare(strict_types=1);
+
+namespace Ridibooks\Test\OAuth2\Symfony;
+
+use Ridibooks\OAuth2\Symfony\OAuth2ServiceProviderBundle;
+use Symfony\Bundle\FrameworkBundle\FrameworkBundle;
+use Symfony\Bundle\FrameworkBundle\Kernel\MicroKernelTrait;
+use Symfony\Component\Config\Loader\LoaderInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\HttpKernel\Kernel;
+use Symfony\Component\Routing\RouteCollectionBuilder;
+
+class TestKernel extends Kernel
+{
+    use MicroKernelTrait;
+
+    public function registerBundles()
+    {
+        return [
+            new FrameworkBundle(),
+            new OAuth2ServiceProviderBundle()
+        ];
+    }
+
+    protected function configureContainer(ContainerBuilder $container, LoaderInterface $loader)
+    {
+        $config_dir = self::getConfigDir();
+        $loader->load($config_dir . '/{packages}/*.yml', 'glob');
+        $loader->load($config_dir . '/{services}.yml', 'glob');
+    }
+
+    protected function configureRoutes(RouteCollectionBuilder $routes)
+    {
+        $routes->import(TestController::class, '/', 'annotation');
+    }
+
+    /**
+     * @return string
+     */
+    private static function getConfigDir(): string
+    {
+        return __DIR__ . '/config';
+    }
+}

--- a/tests/Symfony/config/packages/framework.yml
+++ b/tests/Symfony/config/packages/framework.yml
@@ -1,0 +1,3 @@
+framework:
+  secret: ''
+  test: ~

--- a/tests/Symfony/config/packages/o_auth2_service_provider.yml
+++ b/tests/Symfony/config/packages/o_auth2_service_provider.yml
@@ -6,3 +6,4 @@ o_auth2_service_provider:
   user_info_url: https://account.dev.ridi.io/accounts/me/
   token_cookie_domain: .ridi.io
   jwt_secret: secret
+  default_exception_handler: Ridibooks\Test\OAuth2\Symfony\TestExceptionHandler

--- a/tests/Symfony/config/packages/o_auth2_service_provider.yml
+++ b/tests/Symfony/config/packages/o_auth2_service_provider.yml
@@ -1,0 +1,8 @@
+o_auth2_service_provider:
+  client_id: iax7OcCuYJ8Su5p9swjs7RNosL7zYZ4zdV5xyHVx
+  client_secret: vk31iDFzVM1EKQySvkp46TUNjWn9Bvc1wv7CLSwEWzAUDz5GA3iN0QjGktVXi53KCHxIcfq3V62q9aSQkWzB1zx8Um6OWYO4nEqtJYj4uPHnhjDKW7tV4zGeW9yygvZx
+  authorize_url: https://account.dev.ridi.io/ridi/authorize/
+  token_url: https://account.dev.ridi.io/oauth2/token/
+  user_info_url: https://account.dev.ridi.io/accounts/me/
+  token_cookie_domain: .ridi.io
+  jwt_secret: secret

--- a/tests/Symfony/config/services.yml
+++ b/tests/Symfony/config/services.yml
@@ -1,0 +1,8 @@
+services:
+  Ridibooks\Test\OAuth2\Symfony\TestController:
+    class: Ridibooks\Test\OAuth2\Symfony\TestController
+    autowire: true
+    autoconfigure: true
+    public: false
+    arguments:
+      - '@oauth2_service_provider'

--- a/tests/Symfony/index.php
+++ b/tests/Symfony/index.php
@@ -1,0 +1,12 @@
+<?php
+
+require __DIR__ . '/../../lib/Symfony/vendor/autoload.php';
+
+$source_path = __DIR__ . '/../../lib/Symfony';
+$aspect_mock_kernel = \AspectMock\Kernel::getInstance();
+$aspect_mock_kernel->init([
+    'cacheDir' => join(DIRECTORY_SEPARATOR, [__DIR__, 'aspect_mock']),
+    'debug' => true,
+    'includePaths' => [$source_path],
+    'excludePaths' => ["{$source_path}/vendor"]
+]);


### PR DESCRIPTION
# 변경 사항
- Symfony 4용 `OAuth2ServiceProvider`를 추가했습니다.
  - Symfony `Bundle` Installation 방식을 이용합니다.
  - 기본적인 패키지 환경 설정은 Symfony 4에서 권장하는 `yaml`을 이용합니다.
  - Application Controller에서 `@OAuth2` Annotation을 통해, `scopes`, `user_provider`, `exception_handler`를 Custom 지정할 수 있습니다.
- Silex Provider와 Symfony Provider 디렉토리 간 `composer.json` 분리
  - `silex/silex:^1.3` 버전이 `symfony/symfony:^4.0`를 지원하지 않아서 프로젝트 root의 `composer.json`에서 양쪽 프레임워크의 의존성을 같이 위치시키기가 어려워, `lib/Silex`와 `lib/Symfony` 내 composer.json을 각자 두었습니다.
  - 이후에 Silex Provider와 Symfony Provider를 아예 repo 차원에서 분리해보는 것도 고려해볼만 한 것 같습니다. 
- Symfony 4 대응을 위해, `.travis.yml`의 php 버전 Upgrade
- 테스트 코드 작성(`OAuth2MiddlewareTest`)

# 특징
- Silex용 Service Provider와 상당히 유사하게 구현하였기 때문에, 사용 면에서 흐름은 유사합니다.
- Exception Handler는 `Interface`만 추가하였고, 구현체는 추가하지 않았습니다.
  - Exception Handler는 주로 예외를 핸들링하고 적절한 `Response`를 반환하는 데 쓰이는데, 이 `Response`의 포맷이 사용처마다 다를 것 같아서 별도로 한정하지 않는 게 좋을 것 같다는 판단이 들었습니다.

# 사용 방법
자세한 사용 방법은 [README.md](https://github.com/ridi/php-oauth2/blob/symfony-provider/README.md#usage-with-symfony-provider)를 참고해주세요.
