### PR TITLE
getUser()의 return type을 nullable하게 변경

### DIFF
--- a/lib/Symfony/Subscriber/OAuth2Middleware.php
+++ b/lib/Symfony/Subscriber/OAuth2Middleware.php
@@ -89,9 +89,9 @@ class OAuth2Middleware implements EventSubscriberInterface
     }
 
     /**
-     * @return User
+     * @return User|null
      */
-    public function getUser(): User
+    public function getUser(): ?User
     {
         return $this->user;
     }


### PR DESCRIPTION
- Oauth2인증은 사용하지만 로그인이 필수적이지 않은 앤드포인트의 경우, 내부적으로 로그인여부를 확인하는 로직이 필요함
- 이때, 로그인 여부를 확인하기 위한 가장 쉬운 방법은 user가 null인지 아닌지 판단하는 것임