### PR TITLE
Ridibooks\OAuth2\Symfony\Provider\User 클래스 내 Property 추가

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         }
     },
     "require": {
-        "firebase/php-jwt": "^4.0|^5.0"
+        "firebase/php-jwt": "^4.0 || ^5.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^7"

--- a/lib/Silex/composer.json
+++ b/lib/Silex/composer.json
@@ -12,7 +12,7 @@
         }
     },
     "require": {
-        "firebase/php-jwt": "^4.0|^5.0"
+        "firebase/php-jwt": "^4.0 || ^5.0"
     },
     "require-dev": {
         "guzzlehttp/guzzle": "^6.3",

--- a/lib/Symfony/Provider/User.php
+++ b/lib/Symfony/Provider/User.php
@@ -13,6 +13,12 @@ class User
     /** @var string */
     private $u_id;
 
+    /** @var string */
+    private $email;
+
+    /** @var bool */
+    private $is_verified_adult;
+
     /**
      * @param string $user_info_json
      * @throws AuthorizationException
@@ -27,6 +33,8 @@ class User
 
         $this->u_idx = $result->idx;
         $this->u_id = $result->id;
+        $this->email = $result->email;
+        $this->is_verified_adult = $result->is_verified_adult;
     }
 
     /**
@@ -43,5 +51,21 @@ class User
     public function getUid(): string
     {
         return $this->u_id;
+    }
+
+    /**
+     * @return string
+     */
+    public function getEmail(): string
+    {
+        return $this->email;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isVerifiedAdult(): bool
+    {
+        return $this->is_verified_adult;
     }
 }

--- a/lib/Symfony/composer.json
+++ b/lib/Symfony/composer.json
@@ -12,7 +12,7 @@
         }
     },
     "require": {
-        "firebase/php-jwt": "^4.0|^5.0"
+        "firebase/php-jwt": "^4.0 || ^5.0"
     },
     "require-dev": {
         "symfony/symfony": "^4.0",

--- a/tests/Symfony/OAuth2MiddlewareTest.php
+++ b/tests/Symfony/OAuth2MiddlewareTest.php
@@ -33,6 +33,7 @@ class OAuth2MiddlewareTest extends WebTestCase
                         "result" => [
                             "id" => TokenConstant::USERNAME,
                             "idx" => TokenConstant::USER_IDX,
+                            "email" => 'oauth2-test@ridi.com',
                             "is_verified_adult" => true,
                         ],
                         "message" => "정상적으로 완료되었습니다."


### PR DESCRIPTION
Account 서버 계정 정보 조회 API response 중 `u_id`, `u_idx` 이외에 `email`, `is_verified_adult` property가 정의 되어 있는데, `Ridibooks\OAuth2\Symfony\Provider\User` 클래스에서 이 두 개의 property를 정의하고 있지 않아서, `ridi/php-oauth2` 라이브러리 사용처에서 이 두 값을 사용 가능하도록 수정했습니다.

이번에 수정하면서, `composer.json`의 `firebase/php-jwt` 패키지의 version constraint format이 잘못된 것을 발견해, 같이 수정했습니다.
- https://getcomposer.org/doc/articles/versions.md#version-range