### PR TITLE
Fix response type & Add null check

### DIFF
--- a/lib/Authorization/Api/JwkApi.php
+++ b/lib/Authorization/Api/JwkApi.php
@@ -3,6 +3,7 @@
 namespace Ridibooks\OAuth2\Authorization\Api;
 
 use GuzzleHttp\Client;
+use GuzzleHttp\Psr7\Response;
 use Ridibooks\OAuth2\Authorization\Exception\AccountServerException;
 use Ridibooks\OAuth2\Authorization\Exception\ClientRequestException;
 

--- a/lib/Symfony/Provider/OAuth2ServiceProvider.php
+++ b/lib/Symfony/Provider/OAuth2ServiceProvider.php
@@ -104,7 +104,7 @@ class OAuth2ServiceProvider
      */
     private function getCacheItemPool(): ?CacheItemPoolInterface
     {
-        if (!array_key_exists('cache_item_pool', $this->configs)) {
+        if (!array_key_exists('cache_item_pool', $this->configs) || is_null($this->configs['cache_item_pool'])) {
             return null;
         }
 


### PR DESCRIPTION
Response type 이 잘못 들어가서 PHP 런타임 에러를 발생시켰습니다. 또한, cache_item_pool 환경 설정이 빈 값이면 Null이라고 명시된 값으로 전환되어서 주입되어 에러를 발생시켜 해당 체크도 추가했습니다.